### PR TITLE
Warnings from Elixir 1.5

### DIFF
--- a/lib/basic_types.ex
+++ b/lib/basic_types.ex
@@ -278,15 +278,15 @@ defmodule PropCheck.BasicTypes do
 
   @doc "List of any types, i.e. `list(any)`"
   @spec list() :: type
-  def list(), do: list(any)
+  def list(), do: list(any())
 
   @doc "Tuples of any types, i.e. `loose_tuple(any)`"
   @spec tuple() :: type
-  def tuple(), do: loose_tuple(any)
+  def tuple(), do: loose_tuple(any())
 
   @doc "An Erlang string, i.e. `list(char)`"
   @spec char_list() :: type
-  def char_list(), do: list(char)
+  def char_list(), do: list(char())
 
   @doc "weighted_union(FreqChoices)"
   @spec wunion([{frequency,raw_type},...]) :: type
@@ -294,7 +294,7 @@ defmodule PropCheck.BasicTypes do
 
   @doc "Term is a synonym for `any`"
   @spec term() :: type
-  def term(), do: any
+  def term(), do: any()
 
   @doc "timeout values, i.e. `union([non_neg_integer() | :infinity])`"
   @spec timeout() :: type
@@ -329,15 +329,15 @@ defmodule PropCheck.BasicTypes do
 
   @doc "Large_int is equivalent to `integer`"
   @spec large_int() :: type
-  def large_int(), do: integer
+  def large_int(), do: integer()
 
   @doc "real is equivalent to `float`"
   @spec real() :: type
-  def real(), do: float
+  def real(), do: float()
 
   @doc "bool is equivalent to `boolean`"
   @spec bool() :: type
-  def bool(), do: boolean
+  def bool(), do: boolean()
 
   @doc "choose is equivalent to `integer(low, high)`"
   @spec choose(ext_int, ext_int) :: type

--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -913,9 +913,9 @@ defmodule PropCheck do
       us2time(:binary.decode_unsigned(hash))
     end
 
-    defp time2us({ms, s, us}), do: ms*tera + s*mega + us
+    defp time2us({ms, s, us}), do: ms*tera() + s*mega() + us
     defp us2time(n) do
-      {rem(div(n, tera), mega), rem(div(n, mega), mega), rem(n, mega)}
+      {rem(div(n, tera()), mega()), rem(div(n, mega()), mega()), rem(n, mega())}
     end
 
     defp syntax_error(err), do: raise(ArgumentError, "Usage: " <> err)


### PR DESCRIPTION
This commit resolves simple warnings similar to this one:

```
warning: variable "tera" does not exist and is being expanded to "tera()", please use parentheses to remove the ambiguity or change the variable name
  lib/propcheck.ex:916
```

With this commit, the remaining warnings as of 35bfdaf are:

```
$ mix compile --force                                
Compiling 9 files (.ex)                   
warning: variable "state" is unused
  lib/result.ex:44

warning: String.to_char_list/1 is deprecated, use String.to_charlist/1
  lib/propcheck.ex:872

warning: String.to_char_list/1 is deprecated, use String.to_charlist/1
  lib/propcheck.ex:893

warning: function run/1 is unused
  lib/propcheck.ex:707

warning: function run/2 is unused
  lib/propcheck.ex:708

warning: the char_list() type is deprecated, use charlist()
  lib/propcheck.ex:315

warning: the char_list() type is deprecated, use charlist()
  lib/propcheck.ex:279

warning: Dict.fetch/2 is deprecated, use the Map module for working with maps or the Keyword module for working with keyword lists
  lib/type.ex:167

warning: Dict.fetch/2 is deprecated, use the Map module for working with maps or the Keyword module for working with keyword lists
  lib/type.ex:199
```