### PR TITLE
Test Elixir v1.3, v1.4 and v1.5 on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: elixir
-notifications:
-  recipients:
-    - klaus.alfert@googlemail.com
-otp_release:
-  - 18.2.1
 elixir:
-  - 1.3.0
+  - 1.3
+  - 1.4
+  - 1.5
 before_script:
   - mix local.hex --force
 script: "MIX_ENV=test mix do deps.get, deps.compile, test --cover --trace"


### PR DESCRIPTION
This commit changes `.travis.yml` in order to check multiple Elixir versions, in case that `propcheck` should support more than only the newest release.

Note that the commit removes `notifications`, as I do not know if a failing build on my branch would then send unneeded notifications. If this pull request will be accepted, I will re-add the notification again first.

Also note that I stripped out `otp_release`, as Travis will take care of picking a suitable release. Further, the commit does not specify the PATCH release version of Elixir, allowing Travis to simply use the newest release with the provided MAJOR.MINOR version.