### PR TITLE
Fix Elixir 1.5 warning and add some robustness

### DIFF
--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -276,7 +276,7 @@ defmodule PropCheck do
     @type user_opts :: [user_opt] | user_opt
     @type outer_test :: :proper.outer_test
     @type test :: :proper.test
-    @type output_fun :: ((char_list,[term]) -> :ok)
+    @type output_fun :: ((charlist,[term]) -> :ok)
     @type size :: non_neg_integer
     @type user_opt :: :quiet
     		  | :verbose
@@ -312,7 +312,7 @@ defmodule PropCheck do
     @type module_result :: long_module_result | short_module_result
 
     @type sample :: [any]
-    @type title :: char_list | atom | String.t
+    @type title :: charlist | atom | String.t
     @type stats_printer :: ((sample) -> :ok)
     		       | ((sample, output_fun) -> :ok)
 
@@ -869,7 +869,7 @@ defmodule PropCheck do
     """
     @spec measure(test, title, number | [number]) :: test
     def measure(test, title, num) when is_binary(title) do
-      measure(test, String.to_char_list(title), num)
+      measure(test, String.to_charlist(title), num)
     end
     def measure(test, title, num), do:
       :proper.measure(title, num, test)
@@ -890,7 +890,7 @@ defmodule PropCheck do
     the given title `title` above the statistics.
     """
     @spec with_title(title) :: stats_printer
-    def with_title(title) when is_binary(title), do: with_title(String.to_char_list(title))
+    def with_title(title) when is_binary(title), do: with_title(String.to_charlist(title))
     def with_title(title), do: :proper.with_title(title)
 
     @doc """

--- a/lib/type.ex
+++ b/lib/type.ex
@@ -26,7 +26,7 @@ defmodule PropCheck.Type do
 
 	defmodule TypeExpr do
 		@moduledoc false
-		
+
 		@typedoc """
 		Various type constructors, `:ref` denote a reference to an existing type or
 		parameter, `:literal` means a literal value, in many cases, this will be an atom value.
@@ -164,7 +164,7 @@ defmodule PropCheck.Type do
 	@spec is_recursive(mfa, env ) :: boolean
 	def is_recursive({_m, _f, _a} = t, env) do
 		# ensure that t is defined in env, otherwise we cannot check anything
-		{:ok, type} = env |> Dict.fetch(t)
+		{:ok, type} = env |> Map.fetch(t)
 		%__MODULE__{} = type
 		is_recursive(t, type, env)
 	end
@@ -196,7 +196,7 @@ defmodule PropCheck.Type do
 			_ -> # anything other must be present in the environment
 				#
 				# Hmm, what about types of other modules (=mfa) or parameterized types?
-				{:ok, t} = env |> Dict.fetch(type)
+				{:ok, t} = env |> Map.fetch(type)
 				is_recursive(mfa, t, env)
 		end
 	end

--- a/test/master_statem_test.exs
+++ b/test/master_statem_test.exs
@@ -39,12 +39,18 @@ defmodule PropCheck.Test.MasterStateM do
     |> Enum.filter(&(Atom.to_string(&1) |> String.starts_with?("player_")))
     |> Enum.each(fn name ->
       pid = Process.whereis(name)
+      # nice idea from José Valim: Monitor the process ...
+      ref = Process.monitor(name)
       if is_pid(pid) and Process.alive?(pid) do
         try do
           Process.exit(pid, :kill)
         catch
           _what, _value -> Logger.debug "Already killed process #{name}"
         end
+      end
+      # ... and wait for the DOWN message.
+      receive do
+        {:DOWN, ^ref, :process, _object, _reason} -> :ok
       end
     end)
   end

--- a/test/master_statem_test.exs
+++ b/test/master_statem_test.exs
@@ -61,14 +61,14 @@ defmodule PropCheck.Test.MasterStateM do
 
   def command(players) do
     if (Enum.count(players) > 0) do
-      player_list = players |> Set.to_list
+      player_list = players |> MapSet.to_list
       oneof([
-        {:call, PingPongMaster, :add_player, [name]},
+        {:call, PingPongMaster, :add_player, [name()]},
         {:call, PingPongMaster, :remove_player, [oneof(player_list)]},
         {:call, PingPongMaster, :get_score, [oneof(player_list)]}
         ])
     else
-      {:call, PingPongMaster, :add_player, [name]}
+      {:call, PingPongMaster, :add_player, [name()]}
     end
   end
 
@@ -80,7 +80,7 @@ defmodule PropCheck.Test.MasterStateM do
   #####################################################
 
   @doc "initial model state of the state machine"
-  def initial_state(), do: HashSet.new
+  def initial_state(), do: MapSet.new
 
   @doc """
   Update the model state after a successful call. The `state` parameter has
@@ -89,11 +89,11 @@ defmodule PropCheck.Test.MasterStateM do
   """
   def next_state(state, _value, {:call, PingPongMaster, :add_player, [name]}) do
     #IO.puts "next_state: add player #{name} in model #{inspect state}"
-    state |> Set.put(name)
+    state |> MapSet.put(name)
   end
   def next_state(state, _value, {:call, PingPongMaster, :remove_player, [name]}) do
     #IO.puts "next_state: remove player #{name} in model #{inspect state}"
-    s = state |> Set.delete(name)
+    s = state |> MapSet.delete(name)
     #IO.puts "next_state: the new state is #{inspect s}"
     s
   end
@@ -101,7 +101,7 @@ defmodule PropCheck.Test.MasterStateM do
 
   @doc "can the call in the current state be made?"
   def precondition(players, {:call, PingPongMaster, :remove_player, [name]}) do
-    players |> Set.member?(name)
+    players |> MapSet.member?(name)
   end
   def precondition(_state, _call),  do: true
 
@@ -112,7 +112,7 @@ defmodule PropCheck.Test.MasterStateM do
   """
   def postcondition(players, {:call, PingPongMaster, :remove_player, [name]}, _r = {:removed, n}) do
     # IO.puts "postcondition: remove player #{name} => #{inspect r} in state: #{inspect players}"
-    (name == n) and (players |> Set.member?(name))
+    (name == n) and (players |> MapSet.member?(name))
   end
   def postcondition(_players, {:call, PingPongMaster, :get_score, [_name]}, score) do
     score == 0

--- a/test/pingpong_fsm_test.exs
+++ b/test/pingpong_fsm_test.exs
@@ -15,7 +15,7 @@ defmodule PropCheck.Test.PingPongFSM do
     numtests(1_000, forall cmds in commands(__MODULE__) do
       trap_exit do
         kill_all_player_processes()
-        {:ok, pid} = PingPongMaster.start_link()
+        {:ok, _pid} = PingPongMaster.start_link()
         # :ok = :sys.install(PingPongMaster, {&log_message/3, :no_state})
         # :ok = :sys.trace(PingPongMaster, true)
         r = run_commands(__MODULE__, cmds)

--- a/test/pingpong_fsm_test.exs
+++ b/test/pingpong_fsm_test.exs
@@ -38,10 +38,9 @@ defmodule PropCheck.Test.PingPongFSM do
   end
 
   defp wait_for_master_to_stop() do
-    pid = Process.whereis(PingPongMaster)
-    if is_pid(pid) and Process.alive?(pid) do
-      :timer.sleep(1)
-      wait_for_master_to_stop()
+    ref = Process.monitor(PingPongMaster)
+    receive do
+      {:DOWN, ^ref, :process, _object, _reason} -> :ok
     end
   end
 

--- a/test/pingpong_statem_test.exs
+++ b/test/pingpong_statem_test.exs
@@ -80,10 +80,10 @@ defmodule PropCheck.Test.PingPongStateM do
   def name(%__MODULE__{players: player_list}), do: elements player_list
 
   def command(%__MODULE__{players: []}), do:
-    {:call, PingPongMaster, :add_player, [name]}
+    {:call, PingPongMaster, :add_player, [name()]}
   def command(state) do
     oneof([
-      {:call, PingPongMaster, :add_player, [name]},
+      {:call, PingPongMaster, :add_player, [name()]},
       {:call, PingPongMaster, :remove_player, [name(state)]},
       {:call, PingPongMaster, :get_score, [name(state)]},
       {:call, PingPongMaster, :play_ping_pong,[name(state)]},

--- a/test/stack_test.exs
+++ b/test/stack_test.exs
@@ -12,14 +12,14 @@ defmodule PropCheck.StackTypeTest do
 
 
 	property "pop(push) = original" do
-		forall {s, x} in {Stack.stack(integer), integer} do
+		forall {s, x} in {Stack.stack(integer()), integer()} do
 			{_y, t} = s |> Stack.push(x) |> Stack.pop
 			s == t
 		end
 	end
 
 	property "push make a stack bigger" do
-		forall {s, x} in {Stack.stack(integer), integer} do
+		forall {s, x} in {Stack.stack(integer()), integer()} do
 			(Stack.size(s) + 1) == Stack.size(s |> Stack.push(x))
 		end
 	end

--- a/test/support/movie_server.ex
+++ b/test/support/movie_server.ex
@@ -14,7 +14,7 @@ defmodule PropCheck.Test.MovieServer do
     next_pass: 0
 
   def start_link(), do:
-    GenServer.start_link(__MODULE__, [], name: {:local, __MODULE__})
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
 
   def stop(), do: GenServer.call(__MODULE__, :stop)
 

--- a/test/tree_test.exs
+++ b/test/tree_test.exs
@@ -11,8 +11,8 @@ defmodule PropCheck.TreeTest do
 		# the faulty tree has a default-value, which occurs more often#
 		# than other values. We also delete this default-value, hence
 		# the buggy delete method should fail.
-		faulty_tree = let x <- integer do
-			{x, tree(default(x, integer))}
+		faulty_tree = let x <- integer() do
+			{x, tree(default(x, integer()))}
 		end
 
 		fails(forall {x, t} <- faulty_tree do
@@ -23,7 +23,7 @@ defmodule PropCheck.TreeTest do
 
 	# delete2 is not faulty
 	property "delete2", [:verbose, {:max_size, 20}]  do
-		forall {x, t} <- {integer, tree(integer)} do
+		forall {x, t} <- {integer(), tree(integer())} do
 				tsize = t |> Tree.pre_order |> Enum.count
 				(not Tree.member(Tree.delete2(t, x), x))
 				|> collect(tsize)
@@ -34,7 +34,7 @@ defmodule PropCheck.TreeTest do
 	# Example of a PBT strategy: finding two distinct computations that should
 	# result in the same value.
 	property "sum" do
-		forall t <- tree(integer) do
+		forall t <- tree(integer()) do
 			Tree.pre_order(t) |> Enum.sum == Tree.tree_sum(t)
 		end
 	end

--- a/test/type_test.exs
+++ b/test/type_test.exs
@@ -189,9 +189,9 @@ defmodule PropCheck.Test.TypeTest do
 
 		env = PropCheck.Type.create_environment(types, mod)
 
-		assert env |> Dict.has_key?({mod, :any_fun, 0})
-		assert env |> Dict.has_key?({mod, :my_non_empty_list, 1})
-		assert env |> Dict.has_key?({mod, :safe_stack, 1})
+		assert env |> Map.has_key?({mod, :any_fun, 0})
+		assert env |> Map.has_key?({mod, :my_non_empty_list, 1})
+		assert env |> Map.has_key?({mod, :safe_stack, 1})
 	end
 
 	test "check non-recursive types" do
@@ -220,7 +220,7 @@ defmodule PropCheck.Test.TypeTest do
 		mod = PropCheck.Test.Types
 		types = PropCheck.Test.Types.__type_debug__()
 		assert length(types) > 0
-		env = Type.create_environment(types, mod)
+		_env = Type.create_environment(types, mod)
 
 	 	# assert Type.is_recursive({mod, :t_nat, 0}, env)
 	 	Logger.error "No support yet, thus: testing check mutual recursive types is not executed!"
@@ -233,14 +233,14 @@ defmodule PropCheck.Test.TypeTest do
 		env = Type.create_environment(types, mod)
 
 		type_mfa = {mod, :my_numbers, 0}
-		ast = Type.type_generator(type_mfa, env |> Dict.get(type_mfa))
+		_ast = Type.type_generator(type_mfa, env |> Map.get(type_mfa))
 	end
 
 	test "all to be generated functions are there" do
 		mod = PropCheck.Test.Types
 		types = PropCheck.Test.Types.__type_debug__()
 		assert length(types) > 0
-		env = Type.create_environment(types, mod)
+		_env = Type.create_environment(types, mod)
 
 		mod.my_numbers()
 	end


### PR DESCRIPTION
This pull request deals with three changes: 
* Eliminating all Elixir 1.5 warnings (functions and deprecations)
* Fixing a bug in the movie server, which could not run at all
* Add a more robust version for waiting of killed processes. This should help to become more robust
  regarding concurrencies and thereby resolving some spurious errors when running tests for 
  the ping pong game. 