### PR TITLE
Bump PropEr to 1.2.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -65,7 +65,7 @@ defmodule Propcheck.Mixfile do
       {:earmark, ">= 0.2.1", only: :dev},
       # {:proper, git: "../../erlang/proper/proper"}
       # {:proper, github: "manopapad/proper", ref: "fa58f8" } # from 26.05.2015
-      {:proper, "~> 1.1.1-beta"}
+      {:proper, "~> 1.2.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -9,5 +9,5 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
-  "proper": {:hex, :proper, "1.1.1-beta", "5eef3fa0cae017ecb4bf6fd6a144349a048e999223a4f1e98ce372ff1772edd3", [:rebar3], []},
+  "proper": {:hex, :proper, "1.2.0", "1466492385959412a02871505434e72e92765958c60dba144b43863554b505a4", [:make, :mix, :rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []}}


### PR DESCRIPTION
This bumps the PropEr dependency to 1.2.0. `mix test` did succeed on my machine (with Elixir v1.5) and on Travis for Elixir v1.4 and v1.5, but it failed on Travis with Elixir v1.3. If PropCheck should support Elixir v1.3, this needs more investigation.