### PR TITLE
Feature/mix integration of propcheck and counter examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.0.3
 * Counter examples are automatically stored and reapplied until the properties work
   or the counter examples are deleted. See https://github.com/alfert/propcheck/pull/18
+* Mix configuration for counter examples file and for inspecting and cleaning
+  counter examples.
 
 ## 0.0.2
 * Fixed a lot of 1.5 (and 1.4) Elixir warnings thanks to https://github.com/evnu

--- a/README.md
+++ b/README.md
@@ -12,10 +12,33 @@ To use PropCheck with your project, add it as a dependency to `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:propcheck, "~> 0.0.1", only: :test, runtime: false}
+    {:propcheck, "~> 0.0.3", only: :test, runtime: false}
   ]
 end
 ```
+
+## Basic Usage and Build Configuration
+PropCheck allows to define properties, which automatically executed via `ExUnit`
+when running `mix test`. Details about the `property` macro are found in
+`PropCheck.Properties`,  details about how to specify the property conditions
+are documented in `PropCheck`, the basic data generators are found in
+`PropCheck.BasicTypes`.
+
+For PropCheck, there is only one configuration option. All found counter examples
+are stored in a file, the name of which is configurable in `mix.exs` as part of
+the `project` configuration:
+
+```elixir
+def project() do
+  [ # many other options
+    propcheck: [counter_examples: "filename"]
+  ]
+end
+```
+
+Per default, the counter examples file is stored in the build directory, independent
+from the build environment.
+
 
 ## Links to other documentation
 

--- a/lib/app.ex
+++ b/lib/app.ex
@@ -1,6 +1,7 @@
 defmodule PropCheck.App do
   use Application
 
+  alias PropCheck.Mix
   @moduledoc false
 
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
@@ -11,7 +12,8 @@ defmodule PropCheck.App do
     children = [
       # Define workers and child supervisors to be supervised
       # worker(Propcheck.Worker, [arg1, arg2, arg3])
-      worker(PropCheck.CounterStrike, ["counterexamples.dets", [name: PropCheck.CounterStrike]])
+      worker(PropCheck.CounterStrike,
+        [Mix.counter_example_file(), [name: PropCheck.CounterStrike]])
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/basic_types.ex
+++ b/lib/basic_types.ex
@@ -181,7 +181,7 @@ defmodule PropCheck.BasicTypes do
 
   @doc """
   All lists whose i-th element is an instance of the type at index i of
- ``list_of_types`. Also written simply as a list of types.
+  `list_of_types`. Also written simply as a list of types.
   """
   @spec fixed_list([raw_type()]) :: type
   defdelegate fixed_list(list_of_types), to: :proper_types

--- a/lib/counterstrike.ex
+++ b/lib/counterstrike.ex
@@ -11,20 +11,12 @@ defmodule PropCheck.CounterStrike do
   afterwards.
   """
 
+  @moduledoc false
+
   use GenServer
   require Logger
 
   defstruct [counter_examples: %{}, dets: nil]
-
-  #################################################
-  ##
-  ## Das funktioniert so nicht:
-  ## - ETS und DETS sind globale benannte Resourcen,
-  ##   lokale (erneute) Erstellung kann zu Fehlern führen
-  ## - Identifikation ist so mehrdeutig
-  ##
-  ##
-  #################################################
 
   def start_link(filename \\ 'propcheck.dets', opts \\[])
   def start_link(filename, opts) when is_binary(filename), do: start_link(String.to_charlist(filename), opts)
@@ -45,7 +37,9 @@ defmodule PropCheck.CounterStrike do
   end
 
   @doc """
-  Retrieves the counter example for the given property. Returns
+  Retrieves the counter example for the given property.
+
+  Returns
   `:none` if there are no counterexamples at all, `:others` if
   only other properties have counter examples and `{:ok, counter_example}`
   if a counter example exists for the given property.

--- a/lib/mix.ex
+++ b/lib/mix.ex
@@ -1,12 +1,29 @@
 defmodule PropCheck.Mix do
 
+  @moduledoc false
   def counter_example_file() do
     Mix.Project.config()
     |> Keyword.get(:propcheck, [counter_examples: "counterexamples.dets"])
     |> Keyword.get(:counter_examples)
   end
 end
+
 defmodule Mix.Tasks.Propcheck do
+
+  @moduledoc """
+  PropCheck runs property checking as part of ExUnit test and
+  stores counter examples of failing properties in order to
+  reapply them in the next test run.
+
+  The file name for the counter examples can be configured in `mix.exs`
+  in the project configuration as
+
+      propcheck: [counter_example: "filename"]
+
+  With `mix propcheck.inspect` you can inspect the found counter examples,
+  with `mix propcheck.clean` the file is deleted afterwards.
+  """
+
   defmodule Clean do
     use Mix.Task
     @moduledoc """
@@ -15,6 +32,7 @@ defmodule Mix.Tasks.Propcheck do
 
     @shortdoc "Removes the counter example file of propcheck"
 
+    @doc false
     def run(_args) do
       File.rm(PropCheck.Mix.counter_example_file())
     end
@@ -28,6 +46,7 @@ defmodule Mix.Tasks.Propcheck do
 
     @shortdoc "Inspects and prints all counter examples."
 
+    @doc false
     def run(_args) do
       filename = PropCheck.Mix.counter_example_file() |> String.to_charlist()
       case :dets.open_file(filename) do

--- a/lib/mix.ex
+++ b/lib/mix.ex
@@ -1,0 +1,42 @@
+defmodule PropCheck.Mix do
+
+  def counter_example_file() do
+    "counterexamples.dets"
+  end
+end
+defmodule Mix.Tasks.Propcheck do
+  defmodule Clean do
+    use Mix.Task
+    @moduledoc """
+    Removes the counter example file of propcheck.
+    """
+
+    @shortdoc "Removes the counter example file of propcheck"
+
+    def run(_args) do
+      File.rm(PropCheck.Mix.counter_example_file())
+    end
+  end
+
+  defmodule Inspect do
+    use Mix.Task
+    @moduledoc """
+    Inspects all counter examples.
+    """
+
+    @shortdoc "Inspects and prints all counter examples."
+
+    def run(_args) do
+      filename = PropCheck.Mix.counter_example_file() |> String.to_charlist()
+      {:ok, ctx} = :dets.open_file(filename)
+      fn {{m,f,a}, counter_example}, counter ->
+        prop = "#{m}.#{f}()"
+        Mix.Shell.IO.info "##{counter}: Property #{prop}: #{inspect counter_example}"
+        counter + 1
+      end
+      |> :dets.foldl(1, ctx)
+    end
+
+  end
+
+end

--- a/lib/mix.ex
+++ b/lib/mix.ex
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Propcheck do
     def run(_args) do
       filename = PropCheck.Mix.counter_example_file() |> String.to_charlist()
       {:ok, ctx} = :dets.open_file(filename)
-      fn {{m,f,a}, counter_example}, counter ->
+      fn {{m, f, _a}, counter_example}, counter ->
         prop = "#{m}.#{f}()"
         Mix.Shell.IO.info "##{counter}: Property #{prop}: #{inspect counter_example}"
         counter + 1

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -51,8 +51,9 @@ defmodule PropCheck.Properties do
   prefix is added to the function name. The value is determined by
   looking up the `counter_example` in `CounterStrike` for the property.
   """
+  @doc false
   @spec tag_property(mfa) :: boolean
-  defp tag_property({m, f, a}) do
+  def tag_property({m, f, a}) do
     mfa = {m, String.to_atom("property_#{f}"), a}
     case CounterStrike.counter_example(mfa) do
       {:ok, _} ->
@@ -66,7 +67,8 @@ defmodule PropCheck.Properties do
   Executes the body `p` of property `name` with PropEr options `opts`
   by ExUnit.
   """
-  defp execute_property(p, name, opts) do
+  @doc false
+  def execute_property(p, name, opts) do
     should_fail = is_tuple(p) and elem(p, 0) == :fails
     # Logger.debug "Execute property #{inspect name} "
     case CounterStrike.counter_example(name) do

--- a/mix.exs
+++ b/mix.exs
@@ -15,6 +15,8 @@ defmodule Propcheck.Mixfile do
      homepage_url: "https://github.com/alfert/propcheck",
      docs: [extras: ["README.md"], extra_section: "Overview"],
      description: description(),
+     propcheck: [counter_examples: "_build/propcheck.ctx"],
+     aliases: aliases(),
      deps: deps()]
   end
 
@@ -46,6 +48,10 @@ defmodule Propcheck.Mixfile do
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_),     do: ["lib"]
 
+
+  def aliases() do
+    [clean: ["clean", "propcheck.clean"]]
+  end
 
   # Dependencies can be Hex packages:
   #


### PR DESCRIPTION
This PR integrates propcheck with mix, such that the 
* counter examples can be examined from mix, 
* they can be deleted and 
* the location of the counter example file can be configured from within mix. 