### PR TITLE
Use mix to retrieve default counterexamples path

### DIFF
--- a/lib/mix.ex
+++ b/lib/mix.ex
@@ -2,8 +2,12 @@ defmodule PropCheck.Mix do
 
   @moduledoc false
   def counter_example_file() do
+    default_path =
+      Mix.Project.build_path()
+      |> Path.dirname()
+      |> Path.join("propcheck.ctex")
     Mix.Project.config()
-    |> Keyword.get(:propcheck, [counter_examples: "_build/propcheck.ctex"])
+    |> Keyword.get(:propcheck, [counter_examples: default_path])
     |> Keyword.get(:counter_examples)
   end
 end


### PR DESCRIPTION
When `_build/` is hardcoded, the path cannot be resolved in applications
within umbrella projects. This fix ensures that we always retrieve the
proper build path, no matter if this is a standalone application or part
of an umbrella.

Without this fix, one may encounter the following error message when running `mix test` in a umbrella application:

```
2017-09-25 07:24:00.612 module=PropCheck.CounterStrike pid=<0.362.0> [info] : Filename: _build/propcheck.ctex, options: [name: PropCheck.CounterStrike]

=INFO REPORT==== 25-Sep-2017::09:24:00 ===
    application: logger
    exited: stopped
    type: temporary
** (Mix) Could not start application propcheck: PropCheck.App.start(:normal, []) returned an error: shutdown: failed to start child: PropCheck.CounterStrike
    ** (EXIT) an exception was raised:
        ** (MatchError) no match of right hand side value: {:error, {:file_error, '_build/propcheck.ctex', :enoent}}
            (propcheck) lib/counterstrike.ex:54: PropCheck.CounterStrike.init/1
            (stdlib) gen_server.erl:365: :gen_server.init_it/2
            (stdlib) gen_server.erl:333: :gen_server.init_it/6
            (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```