### PR TITLE
Resolve warnings and enable warnings-as-errors on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ elixir:
   - 1.5
 before_script:
   - mix local.hex --force
+  - mix do deps.get, deps.compile, compile --warnings-as-errors
 script: "MIX_ENV=test mix do deps.get, deps.compile, test --cover --trace --exclude will_fail:true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ elixir:
 before_script:
   - mix local.hex --force
   - mix do deps.get, deps.compile, compile --warnings-as-errors
-script: "MIX_ENV=test mix do deps.get, deps.compile, test --cover --trace --exclude will_fail:true"
+script: "mix test --cover --trace --exclude will_fail:true"

--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -698,32 +698,6 @@ defmodule PropCheck do
       end
   end
 
-    #doc "Runs all properties of a module and return the list of succeeded and failed properties."
-    #
-    #
-    # This function could serve as an example for storing results of quickcheck
-    # and to do samething with them afterwards, e.g. storing counterexamples
-    # to disk for a second run.
-    defp run(target), do: run(target, [report: true, output: true])
-    defp run(target, opts) do
-       PropCheck.Result.start_link
-       on_output =
-         fn(msg, args) ->
-            PropCheck.Result.message(msg, args)
-            opts[:output] && :io.format(msg, args)
-            :ok
-         end
-       module(target, [:long_result, {:on_output, on_output}])
-       {tests, errors} = PropCheck.Result.status
-       passes = length(tests)
-       failures = length(errors)
-       PropCheck.Result.stop
-       if opts[:report] do
-         IO.puts "#{inspect passes} properties, #{inspect failures} failures."
-       end
-       {tests, errors}
-    end
-
     @doc """
     Sample values from a generator `gen`.
 

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -56,12 +56,10 @@ defmodule PropCheck.Properties do
       end
   end
 
-  @doc """
-  Returns the `failing_prop` tag value for the property. The `property_`
-  prefix is added to the function name. The value is determined by
-  looking up the `counter_example` in `CounterStrike` for the property.
-  """
   @doc false
+  # Returns the `failing_prop` tag value for the property. The `property_`
+  # prefix is added to the function name. The value is determined by
+  # looking up the `counter_example` in `CounterStrike` for the property.
   @spec tag_property(mfa) :: boolean
   def tag_property({m, f, a}) do
     mfa = {m, String.to_atom("property_#{f}"), a}
@@ -73,11 +71,9 @@ defmodule PropCheck.Properties do
     end
   end
 
-  @doc """
-  Executes the body `p` of property `name` with PropEr options `opts`
-  by ExUnit.
-  """
   @doc false
+  # Executes the body `p` of property `name` with PropEr options `opts`
+  # by ExUnit.
   def execute_property(p, name, opts) do
     should_fail = is_tuple(p) and elem(p, 0) == :fails
     # Logger.debug "Execute property #{inspect name} "
@@ -95,10 +91,8 @@ defmodule PropCheck.Properties do
     |> handle_check_results(name, should_fail)
   end
 
-  @doc """
-  Handles the result of executing quick check or a re-check of a counter example.
-  In this method a new found counter example is added to `CounterStrike`.
-  """
+  # Handles the result of executing quick check or a re-check of a counter example.
+  # In this method a new found counter example is added to `CounterStrike`.
   defp handle_check_results(results, name, should_fail) do
     case results do
       true when not should_fail -> true
@@ -129,5 +123,4 @@ defmodule PropCheck.Properties do
       {:ok, {_, [{:abstract_code, {_, ac}}]}} = :beam_lib.chunks(beam, [:abstract_code])
       ac |> Enum.map(&:erl_pp.form/1) |> List.flatten |> IO.puts
   end
-
 end

--- a/lib/result.ex
+++ b/lib/result.ex
@@ -35,13 +35,13 @@ defmodule PropCheck.Result do
   def handle_call({:message, fmt, args}, _from, state) do
     state = cond do
       :lists.prefix('Error', fmt) ->
-        state = %__MODULE__{state |
+        %__MODULE__{state |
             errors: [{state.current, {fmt, args}}|state.errors]}
       :lists.prefix('Failed', fmt) ->
-        state = %__MODULE__{state |
+        %__MODULE__{state |
             errors: [{state.current, {fmt, args}}|state.errors]}
       :lists.prefix('Testing', fmt) ->
-        state = %__MODULE__{state | tests: [args | state.tests], current: args}
+        %__MODULE__{state | tests: [args | state.tests], current: args}
     end
     { :reply, :ok, state }
   end


### PR DESCRIPTION
This changeset fixes simple warnings (unused variable, overridden `@doc`, unused function). Additionally, it enables `--warnings-as-errors` on Travis-CI to catch warnings early. The following warnings were resolved (based on revision 7574170):

```
warning: redefining @doc attribute previously set at line 59
  lib/properties.ex:64: PropCheck.Properties (module)

warning: redefining @doc attribute previously set at line 76
  lib/properties.ex:80: PropCheck.Properties (module)

warning: defp handle_check_results/3 is private, @doc's are always discarded for private functions/macros/types
  lib/properties.ex:98

warning: function run/1 is unused
  lib/propcheck.ex:707

warning: function run/2 is unused
  lib/propcheck.ex:708

warning: variable "state" is unused
  lib/result.ex:44
```