### PR TITLE
Fix PropCheck.equals/2

### DIFF
--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -864,11 +864,32 @@ defmodule PropCheck do
     @doc """
     A custom property that evaluates to `true` only if `a === b`, else
     evaluates to `false` and prints `"A != B"` on the screen.
+
+    ## Examples
+
+        iex> use PropCheck
+        iex> quickcheck(equals(:ok, :ok))
+        :true
+
+        iex> use PropCheck
+        iex> quickcheck(
+        ...> forall x <- :ok do
+        ...>   equals(:ok, x)
+        ...> end)
+        :true
+
+        iex> use PropCheck
+        iex> quickcheck(
+        ...> forall x <- :not_ok do
+        ...>   equals(:ok, x)
+        ...> end)
+        :false
     """
     @spec equals(any, any) :: test
-    def equals(a, b), do:
-        (a === b)
-        |> when_fail(IO.puts("#{inspect a, :pretty} != #{inspect b, :pretty}"))
+    def equals(a, b) do
+      when_fail(
+        a === b, IO.puts("#{inspect a, [pretty: true]} != #{inspect b, [pretty: true]}"))
+    end
 
 
     @doc """

--- a/test/propcheck_test.exs
+++ b/test/propcheck_test.exs
@@ -1,5 +1,7 @@
 defmodule PropcheckTest do
 	use ExUnit.Case
+
+	import ExUnit.CaptureIO
 	require Logger
 
 	doctest(PropCheck)
@@ -16,6 +18,16 @@ defmodule PropcheckTest do
 		refute nil == types
 
 		Logger.debug(inspect types, pretty: true)
+	end
+
+	test "equals/2 outputs on error" do
+	  use PropCheck
+	  assert capture_io(fn ->
+	    quickcheck(
+	      forall x <- :not_ok do
+		equals(:ok, x)
+	      end)
+	  end) =~ ":ok != :not_ok"
 	end
 
   def recode_vars({:var, line, n}), do:


### PR DESCRIPTION
`Kernel.inspect/2` allows using options. For `:pretty`, a boolean value
must follow (`pretty: true`). Otherwise, an error similar to the
following is raised:

    Doctest for `:not_ok` fails with no function clause matching in Kernel.inspect/2.

This commit fixes PropCheck.equals/2 and adds tests (doctest and a test
to check that output is written to stdout on error).