### PR TITLE
Property documentation and test

### DIFF
--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -16,7 +16,8 @@ defmodule PropCheck.Properties do
   as ean `ExUnit` test case of category `property`, which is released as
   part of Elixir 1.3 and allows a nice mix of regular unit test and property
   based testing. This is the reason for the third parameter taking an
-  environment of variables defined in a test setup function.
+  environment of variables defined in a test setup function. In `ExUnit`, this
+  is referred to as a test's "context".
 
   The second parameter sets options for Proper (see `PropCheck` ). The default
   is `:quiet` such that execution during ExUnit runs are silent, as normal
@@ -34,6 +35,7 @@ defmodule PropCheck.Properties do
   only the properties with counter example are run. Another option is to use
   the `--stale` option of `ExUnit` to reduce the amount of tests and properties
   while fixing the code tested by a property.
+
   """
   defmacro property(name, opts \\ [:quiet], var \\ quote(do: _), do: p_block) do
       block = quote do

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -13,7 +13,7 @@ defmodule PropCheck.Properties do
 
   The property macro takes at minimum a name and a `do`-block containing
   the code of the property to be tested. The property code is encapsulated
-  as ean `ExUnit` test case of category `property`, which is released as
+  as an `ExUnit` test case of category `property`, which is released as
   part of Elixir 1.3 and allows a nice mix of regular unit test and property
   based testing. This is the reason for the third parameter taking an
   environment of variables defined in a test setup function. In `ExUnit`, this

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -9,7 +9,7 @@ defmodule PropCheck.Properties do
 
 
   @doc """
-  Defines a property as part of an ExUnit test.
+  Defines a property as part of an ExUnit test.
 
   The property macro takes at minimum a name and a `do`-block containing
   the code of the property to be tested. The property code is encapsulated

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Propcheck.Mixfile do
      name: "PropCheck - Property Testing",
      source_url: "https://github.com/alfert/propcheck",
      homepage_url: "https://github.com/alfert/propcheck",
-     docs: [extras: ["README.md"], extra_section: "Overview"],
+     docs: [main: "readme", extras: ["README.md"], extra_section: "Overview"],
      description: description(),
      propcheck: [counter_examples: "_build/propcheck.ctx"],
      aliases: aliases(),

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -1,0 +1,14 @@
+defmodule PropertiesTest do
+  use ExUnit.Case
+  use PropCheck
+
+  setup do
+    [generator: nat()]
+  end
+
+  property "can use context", [], context do
+    forall n <- context.generator do
+      is_integer(n)
+    end
+  end
+end


### PR DESCRIPTION
This changeset adds a little bit of documentation and a simple context test for the `property` macro and sets the README as the main page of the documentation. The reason for adding "context" to the documentation is to make the third parameter of `property` more obvious.