### PR TITLE
Stabilises State-Machine-Tests and enable Elixir 1.6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ elixir:
   - 1.3
   - 1.4
   - 1.5
+  - 1.6
 before_script:
   - mix local.hex --force
   - mix do deps.get, deps.compile, compile --warnings-as-errors

--- a/lib/statem.ex
+++ b/lib/statem.ex
@@ -230,13 +230,13 @@ defmodule PropCheck.StateM do
 
   @doc """
   Specifies the next state of the abstract state machine, given the
-  current state `s`, the symbolic `call` chosen and its result `Res`. This
+  current state `s`, the symbolic `call` chosen and its result `res`. This
   function is called both at command generation and command execution time
   in order to update the model state, therefore the state `s` and the
   result `Res` can be either symbolic or dynamic.
   """
-  @callback next_state(symbolic_state | dynamic_state,
-    term, symb_call) ::
+  @callback next_state(s :: symbolic_state | dynamic_state,
+    res :: term, call :: symb_call) ::
     symbolic_state | dynamic_state
 
   @doc """

--- a/test/support/movie_server.ex
+++ b/test/support/movie_server.ex
@@ -16,7 +16,13 @@ defmodule PropCheck.Test.MovieServer do
   def start_link(), do:
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
 
-  def stop(), do: GenServer.call(__MODULE__, :stop)
+  def stop() do
+    ref = Process.monitor(__MODULE__)
+    GenServer.call(__MODULE__, :stop)
+    receive do
+      {:DOWN, ^ref, :process, _object, _reason} -> :ok
+    end
+  end
 
   @spec create_account(name) :: password
   def create_account(name), do: GenServer.call(__MODULE__, {:new_account, name})

--- a/test/support/pingpong_master.ex
+++ b/test/support/pingpong_master.ex
@@ -26,10 +26,14 @@ defmodule PropCheck.Test.PingPongMaster do
   end
 
   def stop() do
+    ref = Process.monitor(__MODULE__)
     try do
       GenServer.cast(__MODULE__, :stop)
     catch
       :error, :badarg -> Logger.error "already_dead_master:  #{__MODULE__}"
+    end
+    receive do
+      {:DOWN, ^ref, :process, _object, _reason} -> :ok
     end
   end
 

--- a/test/support/pingpong_master.ex
+++ b/test/support/pingpong_master.ex
@@ -64,6 +64,8 @@ defmodule PropCheck.Test.PingPongMaster do
           ping(name)
       {:tennis, from}   -> send(from, :maybe_later)
       {:football, from} -> send(from, :no_way)
+      msg -> Logger.error "Player #{inspect name} got invalid message #{inspect msg}".
+        exit(:kill)
     end
     # Logger.debug "Player #{inspect name} is recursive"
     ping_pong_player(name, counter + 1)


### PR DESCRIPTION
Originally started as documentation, this piece of work find a nasty flaw in the state machine implementation of the ping-pong master. It should now run stable.