### PR TITLE
List available mix tasks

### DIFF
--- a/lib/mix.ex
+++ b/lib/mix.ex
@@ -13,6 +13,9 @@ defmodule PropCheck.Mix do
 end
 
 defmodule Mix.Tasks.Propcheck do
+  use Mix.Task
+
+  @shortdoc "Print PropCheck help information"
 
   @moduledoc """
   PropCheck runs property checking as part of ExUnit test and
@@ -27,6 +30,11 @@ defmodule Mix.Tasks.Propcheck do
   With `mix propcheck.inspect` you can inspect the found counter examples,
   with `mix propcheck.clean` the file is deleted afterwards.
   """
+
+  def run(_) do
+    Mix.shell.info("Available PropCheck tasks:\n")
+    Mix.Tasks.Help.run(["--search", "propcheck."])
+  end
 
   defmodule Clean do
     use Mix.Task


### PR DESCRIPTION
By calling `mix propcheck`, the available mix tasks are listed:

    $ mix propcheck
    Available PropCheck tasks:

    mix propcheck.clean   # Removes the counter example file of propcheck
    mix propcheck.inspect # Inspects and prints all counter examples.

Additionally, the moduledoc is now used to generate the output for
`mix help propcheck`.