### PR TITLE
Remove control characters from doc strings

### DIFF
--- a/lib/fsm.ex
+++ b/lib/fsm.ex
@@ -119,19 +119,19 @@ defmodule PropCheck.FSM do
 
 
   @doc """
-  Specifies the initial state of the finite state machine. As with
+  Specifies the initial state of the finite state machine. As with
   `PropCheck.StateM.initial_state/0`, its result should be deterministic.
   """
   @callback initial_state() :: state_name
 
   @doc """
-  Specifies what the state data should initially contain. Its result
+  Specifies what the state data should initially contain. Its result
   should be deterministic.
   """
   @callback initial_data() :: state_data
 
   @doc """
-  Similar to `PropCheck.StateM.precondition/2`.
+  Similar to `PropCheck.StateM.precondition/2`.
 
   Specifies the
   precondition that should hold about `state_data` so that `call` can be
@@ -148,7 +148,7 @@ defmodule PropCheck.FSM do
     state_data :: state_data, call :: symb_call) :: boolean
 
   @doc """
-  Similar to `PropCheck.StateM.postcondition/3`. Specifies the
+  Similar to `PropCheck.StateM.postcondition/3`. Specifies the
   postcondition that should hold about the result `res` of the evaluation
   of `call`.
   """
@@ -156,7 +156,7 @@ defmodule PropCheck.FSM do
     state_data :: state_data, call :: symb_call, result :: result) :: boolean
 
   @doc """
-  Similar to `PropCheck.StateM.next_state/3`. Specifies how the
+  Similar to `PropCheck.StateM.next_state/3`. Specifies how the
   transition from `from` to `target` triggered by `call` affects the
   `state_data`. `res` refers to the result of `call` and can be either
   symbolic or dynamic.
@@ -165,7 +165,7 @@ defmodule PropCheck.FSM do
     state_data :: state_data, result :: result, call :: symb_call) :: state_data
 
   @doc """
-  This is an optional callback. When it is not defined (or not exported),
+  This is an optional callback. When it is not defined (or not exported),
   transitions are chosen with equal probability. When it is defined, it
   assigns an integer weight to transitions from `from` to `target`
   triggered by symbolic call `call`. In this case, each transition is chosen
@@ -175,7 +175,7 @@ defmodule PropCheck.FSM do
   @optional_callbacks weight: 3
 
   @doc """
-  A special PropEr type which generates random command sequences,
+  A special PropEr type which generates random command sequences,
   according to a finite state machine specification.
 
   The function takes as
@@ -187,7 +187,7 @@ defmodule PropCheck.FSM do
   def commands(mod), do: :proper_fsm.commands(mod)
 
   @doc """
-  Similar to `commands/1`, but generated command sequences always
+  Similar to `commands/1`, but generated command sequences always
   start at a given state.
 
   In this case, the first command is always
@@ -201,7 +201,7 @@ defmodule PropCheck.FSM do
   defdelegate more_commands(n, cmd_type),           to: PropCheck.StateM
 
   @doc """
-  Evaluates a given symbolic command sequence `cmds` according to the
+  Evaluates a given symbolic command sequence `cmds` according to the
   finite state machine specified in `mod`.
 
   The result is a triple of the form `{history, fsm_state, result}`,
@@ -220,7 +220,7 @@ defmodule PropCheck.FSM do
   def run_commands(mod, cmds, env), do: :proper_fsm.run_commands(mod, cmds, env)
 
   @doc """
-  Extracts the names of the states from a given command execution history.
+  Extracts the names of the states from a given command execution history.
 
   It is useful in combination with functions such as `PropCheck.aggregate/2`
   in order to collect statistics about state transitions during command

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -1,7 +1,7 @@
 defmodule PropCheck.Properties do
 
   @moduledoc """
-  This module defined the `property/4` macro. It is automatically available
+  This module defined the `property/4` macro. It is automatically available
   by `use PropCheck`.
   """
   alias PropCheck.CounterStrike

--- a/lib/statem.ex
+++ b/lib/statem.ex
@@ -218,7 +218,7 @@ defmodule PropCheck.StateM do
   @callback precondition(s :: symbolic_state, call :: symb_call) :: boolean
 
   @doc """
-  Specifies the postcondition that should hold about the result `res` of
+  Specifies the postcondition that should hold about the result `res` of
   performing `call`, given the dynamic state `s` of the abstract state
   machine prior to command execution.
 
@@ -229,7 +229,7 @@ defmodule PropCheck.StateM do
     call:: symb_call, res :: term) :: boolean
 
   @doc """
-  Specifies the next state of the abstract state machine, given the
+  Specifies the next state of the abstract state machine, given the
   current state `s`, the symbolic `call` chosen and its result `res`. This
   function is called both at command generation and command execution time
   in order to update the model state, therefore the state `s` and the
@@ -240,7 +240,7 @@ defmodule PropCheck.StateM do
     symbolic_state | dynamic_state
 
   @doc """
-  Extracts the names of the commands from a given command sequence, in
+  Extracts the names of the commands from a given command sequence, in
   the form of MFAs.
 
   It is useful in combination with functions such as
@@ -250,7 +250,7 @@ defmodule PropCheck.StateM do
   defdelegate command_names(cmds), to: :proper_statem
 
   @doc """
-  A special PropEr type which generates random command sequences,
+  A special PropEr type which generates random command sequences,
   according to an absract state machine specification.
 
   The function takes as
@@ -260,7 +260,7 @@ defmodule PropCheck.StateM do
   defdelegate commands(mod), to: :proper_statem
 
   @doc """
-  Similar to `commands/1`, but generated command sequences always
+  Similar to `commands/1`, but generated command sequences always
   start at a given state.
 
   In this case, the first command is always
@@ -272,7 +272,7 @@ defmodule PropCheck.StateM do
   defdelegate commands(mod, initial_state), to: :proper_statem
 
   @doc """
-  Increases the expected length of command sequences generated from
+  Increases the expected length of command sequences generated from
   `cmd_type` by a factor `n`.
 
   **CAVEAT**<br>
@@ -293,7 +293,7 @@ defmodule PropCheck.StateM do
   end
 
   @doc """
-  A special PropEr type which generates parallel testcases,
+  A special PropEr type which generates parallel testcases,
   according to an absract state machine specification.
 
   The function takes as
@@ -303,13 +303,13 @@ defmodule PropCheck.StateM do
   defdelegate parallel_commands(mod), to: :proper_statem
 
   @doc """
-  Similar to `parallel_commands/1`, but generated command sequences
+  Similar to `parallel_commands/1`, but generated command sequences
   always start at a given state.
   """
   defdelegate parallel_commands(mod, initial_state), to: :proper_statem
 
   @doc """
-  Evaluates a given symbolic command sequence `cmds` according to the
+  Evaluates a given symbolic command sequence `cmds` according to the
   state machine specified in `mod`.
 
   The result is a triple of the form
@@ -341,7 +341,7 @@ defmodule PropCheck.StateM do
   defdelegate run_commands(mod, cmds), to: :proper_statem
 
   @doc """
-  Similar to `run_commands/2`, but also accepts an environment,
+  Similar to `run_commands/2`, but also accepts an environment,
   used for symbolic variable evaluation during command execution. The
   environment consists of `{key::atom, value::any}` pairs. Keys may be
   used in symbolic variables (i.e. `{:var, key}`) whithin the command sequence
@@ -351,7 +351,7 @@ defmodule PropCheck.StateM do
   defdelegate run_commands(mod, cmds, env), to: :proper_statem
 
   @doc """
-  Runs a given parallel testcase according to the state machine
+  Runs a given parallel testcase according to the state machine
   specified in `mod`.
 
   The result is a triple of the form
@@ -368,14 +368,14 @@ defmodule PropCheck.StateM do
   defdelegate run_parallel_commands(mod, testcase),  to: :proper_statem
 
   @doc """
-  Similar to `run_parallel_commands/2`, but also accepts an
+  Similar to `run_parallel_commands/2`, but also accepts an
   environment used for symbolic variable evaluation, exactly as described in
   `run_commands/3`.
   """
   defdelegate run_parallel_commands(mod, testcase, env), to: :proper_statem
 
   @doc """
-  Returns the symbolic state after running a given command sequence,
+  Returns the symbolic state after running a given command sequence,
   according to the state machine specification found in `mod`.
 
   The commands are not actually executed.
@@ -383,7 +383,7 @@ defmodule PropCheck.StateM do
   defdelegate state_after(mod, cmds), to: :proper_statem
 
   @doc """
-  Behaves exactly like `Enum.zip/2`.
+  Behaves exactly like `Enum.zip/2`.
 
   Zipping stops when the shortest list stops. This is
   useful for zipping a command sequence with its (failing) execution history.


### PR DESCRIPTION
This removes backspace (`^H` in vim) control characters from doc strings.