### PR TITLE
Allows more than two bindings in a let

### DIFF
--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -541,10 +541,10 @@ defmodule PropCheck do
     end
     defp let_bind({:<-, _, [var, rawtype]} = _bind), do: {var, rawtype}
     defp let_bind([{:<-, _, [var, rawtype]}]) do
-      {var, rawtype}
+      [{var, rawtype}]
     end
     defp let_bind([{:<-, _, [var, rawtype]} | rest]) do
-      [{var, rawtype}, let_bind(rest)]
+      [{var, rawtype} | let_bind(rest)]
     end
 
     @doc """

--- a/test/propcheck_test.exs
+++ b/test/propcheck_test.exs
@@ -20,6 +20,26 @@ defmodule PropcheckTest do
 		Logger.debug(inspect types, pretty: true)
 	end
 
+  test "let/2 generates larger lists of bindings" do
+    use PropCheck
+
+    let_gen = let [
+      m <- nat(),
+      n <- nat(),
+      o <- nat()
+    ] do
+      [m, n, o]
+      :ok
+    end
+
+    assert capture_io(fn ->
+      quickcheck(
+        forall x <- let_gen do
+          equals(:ok, x)
+        end)
+    end) =~ "Passed"
+  end
+
 	test "equals/2 outputs on error" do
 	  use PropCheck
 	  assert capture_io(fn ->


### PR DESCRIPTION
When cycling through the let with the `,` in the list we don't append
the list as expected. This works fine with only two items in the
bindings list, but with more than that we start to get nested lists
which turn into argument errors when we try to call `elem(x, 0)`.
Changing to a pipe fixes the issue because it will concatenate the
lists, but the final recursion needs to return a list to be appended
too.

Amos King @adkron <amos@binarynoggin.com>