### PR TITLE
order of tuple elements for :rerun corrected

### DIFF
--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -129,7 +129,7 @@ defmodule PropCheck.Properties do
           #{inspect counter_example, pretty: true}
           """,
               expr: nil]
-      {counter_example, :rerun_failed} when is_list(counter_example) ->
+      {:rerun_failed, counter_example} when is_list(counter_example) ->
         CounterStrike.add_counter_example(name, counter_example)
         raise ExUnit.AssertionError, [
           message: """


### PR DESCRIPTION
Simple, yet fatal bug within the rerun code. 