### PR TITLE
Dialyze it

### DIFF
--- a/lib/basic_types.ex
+++ b/lib/basic_types.ex
@@ -23,7 +23,7 @@ defmodule PropCheck.BasicTypes do
   @type ext_float :: float | :inf
 
   @typedoc "The internal representation of a basic type in PropEr"
-  @opaque raw_type :: :proper_types.raw_type
+  @type raw_type :: :proper_types.raw_type
 
   @typedoc "The internal representation of a type in PropEr"
   @type type :: :proper_types.type

--- a/lib/basic_types.ex
+++ b/lib/basic_types.ex
@@ -26,7 +26,7 @@ defmodule PropCheck.BasicTypes do
   @opaque raw_type :: :proper_types.raw_type
 
   @typedoc "The internal representation of a type in PropEr"
-  @opaque type :: type
+  @type type :: :proper_types.type
 
   @type frequency :: pos_integer
 

--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -279,7 +279,7 @@ defmodule PropCheck do
         end
     end
 
-    @opaque counterexample :: :proper.counterexample
+    @type counterexample :: :proper.counterexample
     @type user_opts :: [user_opt] | user_opt
     @type outer_test :: :proper.outer_test
     @type test :: :proper.test

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -144,7 +144,7 @@ defmodule PropCheck.Properties do
     end
   end
 
-  defp mfa_to_string({m, f, []}) do
+  defp mfa_to_string({m, f, _}) do
     "#{m}.#{f}()"
   end
 

--- a/lib/statem_dsl.ex
+++ b/lib/statem_dsl.ex
@@ -214,7 +214,7 @@ defmodule PropCheck.StateM.DSL do
   @typep cmd_t ::
       {:args, module, String.t, atom, gen_fun_t} # |
       # {:cmd, module, String.t, gen_fun_t}
-  @typep environment :: %{symbolic_var: any}
+  @typep environment :: %{required(symbolic_var) => any}
 
   @typedoc """
   The combined result of the test. It contains the history of all executed commands,
@@ -338,6 +338,7 @@ defmodule PropCheck.StateM.DSL do
   end
 
   # Checks that the precondition holds, required for shrinking
+  @spec is_valid(module, state_t, [BasicTypes.type]) :: boolean
   defp is_valid(_mod, _initial_state, []), do: true
   defp is_valid(mod, initial_state, cmds) do
     # Logger.debug "is_valid: initial=#{inspect initial_state}"
@@ -347,6 +348,7 @@ defmodule PropCheck.StateM.DSL do
     initial_state == first_state and
     is_valid(mod, initial_state, cmds, %{})
   end
+  @spec is_valid(module, state_t, [BasicTypes.type], environment) :: boolean
   defp is_valid(_mod, _state, [], _env), do: true
   defp is_valid(m, state, [call | cmds], env) do
     {_s, {:set, var, c}} = call
@@ -476,6 +478,7 @@ defmodule PropCheck.StateM.DSL do
 
   # replaces all symbolic variables of form `{:var, n}` with
   # the value in `env` (i.e. mapping of symbolic vars to values)
+  @spec replace_symb_vars(symbolic_call | symbolic_var | [symbolic_call | symbolic_var] | any, environment) :: symbolic_call
   defp replace_symb_vars({:call, m, f, args}, env) do
     replaced_m = replace_symb_vars(m, env)
     replaced_f = replace_symb_vars(f, env)

--- a/lib/statem_dsl.ex
+++ b/lib/statem_dsl.ex
@@ -433,7 +433,7 @@ defmodule PropCheck.StateM.DSL do
     end)
   end
 
-  @spec new_state(state_t) :: t
+  @spec new_state(state_t) :: %__MODULE__{}
   defp new_state(initial_state), do: %__MODULE__{state: initial_state}
 
   @spec execute_cmd(state_t, t) :: history_event

--- a/lib/statem_dsl.ex
+++ b/lib/statem_dsl.ex
@@ -504,12 +504,12 @@ defmodule PropCheck.StateM.DSL do
       {:ok, val} -> val
       _ -> r
     end
-    h = %__MODULE__{state: s,
+    new_h = %__MODULE__{state: s,
       result: result,
       history: [event | h],
       env: Map.put(env, v, value)}
     # Logger.debug "Updated history: #{inspect h, pretty: true}"
-    h
+    new_h
   end
 
   @spec call_next_state(state_t, symbolic_call, any) :: state_t

--- a/lib/statem_dsl.ex
+++ b/lib/statem_dsl.ex
@@ -359,29 +359,8 @@ defmodule PropCheck.StateM.DSL do
     end
   end
 
-  # This is directly taken from PropEr's proper_statem.erl
-  # However the shorter gen_commands does already shrinking.
-  # This function is unused but implemented in case
-  # that the shrinking of gen_commands proves to be not good enough. It should
-  # be a private function but since it is unsused, this generates a warning
-  # resulting in an error during CI build. For this
-  # specific reason the function is public.
-  @spec gen_commands_as_proper(module, [cmd_t]) :: BasicTypes.type()
-  @doc false
-  def gen_commands_as_proper(mod, cmd_list) do
-    initial_state = mod.initial_state()
-    such_that (cmds <-
-      let (list <-
-        sized(size, noshrink(gen_cmd_list(size, cmd_list, mod, initial_state, 1)))) do
-          shrink_list(list)
-        end),
-      when: is_valid(mod, initial_state, cmds)
-  end
-
-
-
   # The internally used recursive generator for the command list
-  @spec gen_cmd_list(pos_integer, [cmd_t], module, state_t, pos_integer) :: PropCheck.BasicTypes.type
+  @spec gen_cmd_list(pos_integer, [cmd_t], module, state_t, pos_integer) :: BasicTypes.type
   defp gen_cmd_list(0, _cmd_list, _mod, _state, _step_counter), do: exactly([])
   defp gen_cmd_list(size, cmd_list, mod, state, step_counter) do
     # Logger.debug "gen_cmd_list: cmd_list = #{inspect cmd_list}"

--- a/lib/statem_dsl.ex
+++ b/lib/statem_dsl.ex
@@ -279,7 +279,7 @@ defmodule PropCheck.StateM.DSL do
     queries.
   * if the system under test is in the correct state after the call
     (`post(old_state, arg_list, result) :: boolean`). This is `true` in the
-    default implementation.  
+    default implementation.
 
   These local functions inside the macro are effectively callbacks to guide and
   evolve the model state.
@@ -321,14 +321,14 @@ defmodule PropCheck.StateM.DSL do
   @doc """
   Generates the command list for the given module
   """
-  @spec commands(module) :: :proper_types.type()
+  @spec commands(module) :: BasicTypes.type()
   def commands(mod) do
     cmd_list = command_list(mod, "")
     # Logger.debug "commands:  cmd_list = #{inspect cmd_list}"
     gen_commands(mod, cmd_list)
   end
 
-  @spec gen_commands(module, [cmd_t]) :: :proper_types.type()
+  @spec gen_commands(module, [cmd_t]) :: BasicTypes.type()
   defp gen_commands(mod, cmd_list) do
     initial_state = mod.initial_state()
     gen_cmd = sized(size, gen_cmd_list(size, cmd_list, mod, initial_state, 1))
@@ -365,7 +365,7 @@ defmodule PropCheck.StateM.DSL do
   # be a private function but since it is unsused, this generates a warning
   # resulting in an error during CI build. For this
   # specific reason the function is public.
-  @spec gen_commands_as_proper(module, [cmd_t]) :: :proper_types.type()
+  @spec gen_commands_as_proper(module, [cmd_t]) :: BasicTypes.type()
   @doc false
   def gen_commands_as_proper(mod, cmd_list) do
     initial_state = mod.initial_state()

--- a/lib/statem_dsl.ex
+++ b/lib/statem_dsl.ex
@@ -202,6 +202,10 @@ defmodule PropCheck.StateM.DSL do
   """
   @type history_event :: {state_t, symbolic_call, {any, result_t}}
   @typedoc """
+  The sequence of calls consists of state and symbolic calls.
+  """
+  @type state_call :: {dynamic_state, command}
+  @typedoc """
   The result of the command execution. It contains either the state of the failing
   precondition, the command's return value of the failing postcondition,
   the exception values or `:ok` if everything is fine.
@@ -438,7 +442,7 @@ defmodule PropCheck.StateM.DSL do
   @spec new_state(state_t) :: %__MODULE__{}
   defp new_state(initial_state), do: %__MODULE__{state: initial_state}
 
-  @spec execute_cmd(state_t, t) :: history_event
+  @spec execute_cmd(state_call, t) :: history_event
   defp execute_cmd({_, {:set, v = {:var, _}, sym_c = {:call, _m, _f, _args}}}, prop_state) do
     # Logger.debug "execute_cmd: symb call: #{inspect sym_c}"
     state = prop_state.state

--- a/test/support/pingpong_master.ex
+++ b/test/support/pingpong_master.ex
@@ -60,7 +60,7 @@ defmodule PropCheck.Test.PingPongMaster do
           ping(name)
       {:tennis, from}   -> send(from, :maybe_later)
       {:football, from} -> send(from, :no_way)
-      msg -> Logger.error "Player #{inspect name} got invalid message #{inspect msg}".
+      msg -> Logger.error "Player #{inspect name} got invalid message #{inspect msg}"
         exit(:kill)
     end
     # Logger.debug "Player #{inspect name} is recursive"


### PR DESCRIPTION
Specs and types had some issues and are now corrected. In particular, using opaque types was not a good idea to start with. The DSL implementation was also not correct. 

I expect that this will also help with #45 - nevertheless it is way more correct now.