### PR TITLE
Enhance message on purging counterexamples

### DIFF
--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -136,8 +136,8 @@ defmodule PropCheck.Properties do
           Property #{mfa_to_string name} failed. Counter-Example is:
           #{inspect counter_example, pretty: true}
 
-          Consider running `mix propcheck.clean` if a bug in a generator was identified
-          and fixed. PropCheck cannot identify changes to generators. See
+          Consider running `MIX_ENV=test mix propcheck.clean` if a bug in a generator was
+          identified and fixed. PropCheck cannot identify changes to generators. See
           https://github.com/alfert/propcheck/issues/30 for more details.
           """,
           expr: nil]


### PR DESCRIPTION
This enhances the message introduced with 4692ef8, which outputs an info message on purging counterexamples. This should help avoid users stumbling over `mix propcheck.clean` missing in `MIX_ENV=dev` if propcheck is not allowed in `:dev` (see #73).