### PR TITLE
print stacktrace along with exception

### DIFF
--- a/lib/statem_dsl.ex
+++ b/lib/statem_dsl.ex
@@ -463,8 +463,9 @@ defmodule PropCheck.StateM.DSL do
           {:post_condition, result}
         end
       rescue exc ->
-        Logger.error "Got exception: #{inspect exc}"
-        {:exception, {exc, Exception.format_stacktrace()}}
+        stacktrace = Exception.format_stacktrace(System.stacktrace())
+        Logger.error("Got exeception: #{inspect(exc)}\nstacktrace: #{stacktrace}")
+        {:exception, {exc, stacktrace}}
       catch
         value -> {:exception, value}
         kind, value -> {:exception, {kind, value}}


### PR DESCRIPTION
Without stacktrace, it's difficult to troubleshoot exception sometimes. A sample is shown below

```
     14:40:51.937 [error] Got exception: %UndefinedFunctionError{arity: 0, function: :id, message: nil, module: nil, reason: nil}
```

```
     14:42:16.361 [error] Got exeception: %UndefinedFunctionError{arity: 0, function: :id, message: nil, module: nil, reason: nil}
     stacktrace:     nil.id()
         test/spice/mysql_state_test.exs:372: Spice.MySQLStateTest.update_embed/2
         (propcheck) lib/statem_dsl.ex:459: PropCheck.StateM.DSL.execute_cmd/2
         (propcheck) lib/statem_dsl.ex:441: anonymous fn/2 in PropCheck.StateM.DSL.run_commands/1
         (elixir) lib/enum.ex:1925: Enum."-reduce/3-lists^foldl/2-0-"/3
         test/spice/mysql_state_test.exs:18: anonymous fn/1 in Spice.MySQLStateTest."property fdb vs mysql"/1
         (proper) src/proper.erl:1543: :proper.apply_args/4
         (proper) src/proper.erl:1579: :proper.child/4
         (proper) src/proper.erl:743: anonymous fn/2 in :proper.spawn_link_migrate/1
```