### PR TITLE
Fix level test

### DIFF
--- a/test/level_tpbt_test.exs
+++ b/test/level_tpbt_test.exs
@@ -33,9 +33,6 @@ defmodule PropCheck.Test.LevelTest do
       (prev_path, _temperature) when is_list(prev_path) ->
           let next_steps <- vector(20, step()), do:
             prev_path ++ next_steps
-      ({:"$used",  prev_path, _another_path}, _temperature) when is_list(prev_path) ->
-       let next_steps <- vector(20, step()), do:
-          prev_path ++ next_steps
     end
   end
 

--- a/test/level_tpbt_test.exs
+++ b/test/level_tpbt_test.exs
@@ -101,7 +101,9 @@ defmodule PropCheck.Test.LevelTest do
     level = Level.build_level(level_data)
     %{entrance: entrance} = level
     %{exit: exit_pos} = level
-    forall_targeted path <- path_gen() do
+    # When using a proper-derived generator, we might have to search longer to search for
+    # a successful path.
+    numtests(50_000, forall_targeted path <- path_gen() do
       case Level.follow_path(entrance, path, level) do
         {:exited, _} -> false
         pos ->
@@ -114,7 +116,7 @@ defmodule PropCheck.Test.LevelTest do
             true
           end
       end
-    end
+    end) |> fails()
   end
 
   # prop_exit_targeted(LevelData) ->

--- a/test/level_tpbt_test.exs
+++ b/test/level_tpbt_test.exs
@@ -96,12 +96,12 @@ defmodule PropCheck.Test.LevelTest do
   #              end).
 
 
-  property "Target PBT Level 1 with forall_sa", [:verbose] do
+  property "Target PBT Level 1 with forall_targeted and proper-derived nf", [:verbose] do
     level_data = Level.level1()
     level = Level.build_level(level_data)
     %{entrance: entrance} = level
     %{exit: exit_pos} = level
-    forall_sa path <- target(path_gen_sa()) do
+    forall_targeted path <- path_gen() do
       case Level.follow_path(entrance, path, level) do
         {:exited, _} -> false
         pos ->

--- a/test/level_tpbt_test.exs
+++ b/test/level_tpbt_test.exs
@@ -114,7 +114,6 @@ defmodule PropCheck.Test.LevelTest do
             true
           end
       end
-      |> collect(length(path))
     end
   end
 


### PR DESCRIPTION
This is an attempt at fixing two issues described in #82:

1. Avoiding the PropEr-internal `{:"$user, _, _}` tuple
1. Avoiding to use legacy TPBT macros

The first item is resolved by the second item. It seems that when we use the legacy macros, the internal tuple is returned to the neighbourhood function. When using `forall_targeted` instead of `forall_sa`, this is not longer the case.

Note that when using `forall_targeted`, `collect/1`, can currently not be used, as the macro attempts to apply `:erlang.not/1` onto the result of `collect/1`. Additionally, when using a proper-derived NF, we need to perform more tests until a path is found, as the search space is apparently traversed more randomly.