### PR TITLE
Let-like forall

### DIFF
--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -346,6 +346,16 @@ defmodule PropCheck do
         ...>)
         true
 
+    Similar to `let/2`, multiple types can also be combined in a list of bindings:
+
+        iex> use PropCheck
+        iex> quickcheck(
+        ...> forall [n <- nat(), l <- list(nat())] do
+        ...>   n * Enum.sum(l) >= 0
+        ...> end
+        ...>)
+        true
+
     `forall` allows using `ExUnit` assertions. By default (`:quiet`), no output
     is generated if an assertion does not hold:
 
@@ -554,6 +564,18 @@ defmodule PropCheck do
 
         iex> use PropCheck
         iex> even_factor = let [n <- nat(), m <- nat()] do
+        ...>  n * m * 2
+        ...> end
+        iex> quickcheck(
+        ...>   forall n <- even_factor do
+        ...>     rem(n, 2) == 0
+        ...>   end)
+        true
+
+    Similar to `forall/2`, multiple types can also be put into tuples or lists:
+
+        iex> use PropCheck
+        iex> even_factor = let {n, m} <- {nat(), nat()} do
         ...>  n * m * 2
         ...> end
         iex> quickcheck(

--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -614,14 +614,13 @@ defmodule PropCheck do
     end
 
     defmacro let([{:<-, _, _} | _rest] = bindings, [{:do, gen}]) do
-        bound = let_bind(bindings) |> Enum.reverse
-        vars = bound |> Enum.map(&(elem(&1, 0)))
-        raw_types = bound |> Enum.map(&(elem(&1, 1)))
+        {vars, raw_types} = bindings |> let_bind() |> Enum.reverse() |> Enum.unzip()
         quote do
           :proper_types.bind(unquote(raw_types),
             fn(unquote(vars)) -> unquote(gen) end, false)
         end
     end
+
     defp let_bind(_bind = {:<-, _, [var, rawtype]}), do: {var, rawtype}
     defp let_bind([{:<-, _, [var, rawtype]}]) do
       [{var, rawtype}]

--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -373,15 +373,15 @@ defmodule PropCheck do
     @in_ops [:<-, :in]
     defmacro forall(binding, opts \\ [:quiet], property)
     defmacro forall({op, _, [var, rawtype]}, opts, do: prop) when op in @in_ops do
-      forall1(var, rawtype, opts, prop)
+      forall_impl(var, rawtype, opts, prop)
     end
 
     defmacro forall(bindings, opts, do: prop) do
       {vars, rawtypes} = bindings |> forall_bind() |> Enum.unzip()
-      forall1(vars, rawtypes, opts, prop)
+      forall_impl(vars, rawtypes, opts, prop)
     end
 
-    defp forall1(var, rawtype, opts, prop) do
+    defp forall_impl(var, rawtype, opts, prop) do
       quote do
         :proper.forall(
           unquote(rawtype),

--- a/test/propcheck_test.exs
+++ b/test/propcheck_test.exs
@@ -63,26 +63,37 @@ defmodule PropcheckTest do
     end) == "[1,2,3]\n"
   end
 
-  test "can use assertion in forall" do
+  describe "forall" do
     use PropCheck
-    assert capture_io(fn ->
-      quickcheck(
-        forall _x <- :not_ok, [:verbose] do
-          assert false
-        end
-      )
-    end) =~ "Expected truthy, got false"
-  end
 
-  test "can use assertion in forall without output" do
-    use PropCheck
-    refute capture_io(fn ->
-      quickcheck(
-        forall _x <- :not_ok, [:quiet] do
+    test "can use assertion in forall" do
+      assert capture_io(fn ->
+        quickcheck(
+          forall _x <- :not_ok, [:verbose] do
           assert false
-        end
-      )
-    end) =~ "Expected truthy, got false"
+          end
+        )
+        end) =~ "Expected truthy, got false"
+    end
+
+    test "can use assertion in forall without output" do
+      refute capture_io(fn ->
+        quickcheck(
+          forall _x <- :not_ok, [:quiet] do
+          assert false
+          end
+        )
+        end) =~ "Expected truthy, got false"
+    end
+
+    property "can use let-like assignment in forall" do
+      forall [
+        m <- integer(),
+        n <- integer()
+      ] do
+        is_integer(m) and is_integer(n)
+      end
+    end
   end
 
   def recode_vars({:var, line, n}), do:

--- a/test/propcheck_test.exs
+++ b/test/propcheck_test.exs
@@ -94,6 +94,24 @@ defmodule PropcheckTest do
         is_integer(m) and is_integer(n)
       end
     end
+
+    test "syntax errors are reported" do
+      assert_raise ArgumentError, fn ->
+        Code.compile_string("""
+          use PropCheck
+
+          forall [n operator nat()], do: true
+        """) =~ "Usage:"
+      end
+
+      assert_raise ArgumentError, fn ->
+        Code.compile_string("""
+          use PropCheck
+
+          forall {n <- nat()}, do: true
+        """) =~ "Usage:"
+      end
+    end
   end
 
   def recode_vars({:var, line, n}), do:

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -11,13 +11,4 @@ defmodule PropertiesTest do
       is_integer(n)
     end
   end
-
-  property "can use let-like assignment" do
-    forall [
-      m <- integer(),
-      n <- integer()
-    ] do
-      is_integer(m) and is_integer(n)
-    end
-  end
 end

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -11,4 +11,13 @@ defmodule PropertiesTest do
       is_integer(n)
     end
   end
+
+  property "can use let-like assignment" do
+    forall [
+      m <- integer(),
+      n <- integer()
+    ] do
+      is_integer(m) and is_integer(n)
+    end
+  end
 end


### PR DESCRIPTION
This pull request implements let-like binding for `forall`:

```elixir
  property "can use let-like assignment" do
    forall [
      m <- integer(),
      n <- integer()
    ] do
      is_integer(m) and is_integer(n)
    end
  end
```

Fix #92 