### PR TITLE
Lint with Credo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,20 @@ jobs:
             - _build
             - deps
             - ~/.mix
+  lint:
+    parameters:
+      version:
+        description: Elixir version
+        type: string
+    docker:
+      - image: elixir:<< parameters.version >>
+    steps:
+      - checkout
+      - run: mix local.hex --force
+      - run: mix local.rebar --force
+      - run: MIX_ENV=test mix do deps.get, compile
+      - run: mix credo --strict
+
 workflows:
   build:
     jobs:
@@ -40,4 +54,6 @@ workflows:
           version: "1.7"
       - build:
           name: "Elixir v1.8"
+          version: "1.8"
+      - lint:
           version: "1.8"

--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,159 @@
+# This file contains the configuration for Credo and you are probably reading
+# this after creating it with `mix credo.gen.config`.
+#
+# If you find anything wrong or unclear in this file, please report an
+# issue on GitHub: https://github.com/rrrene/credo/issues
+#
+%{
+  #
+  # You can have as many configs as you like in the `configs:` field.
+  configs: [
+    %{
+      #
+      # Run any exec using `mix credo -C <name>`. If no exec name is given
+      # "default" is used.
+      #
+      name: "default",
+      #
+      # These are the files included in the analysis:
+      files: %{
+        #
+        # You can give explicit globs or simply directories.
+        # In the latter case `**/*.{ex,exs}` will be used.
+        #
+        included: ["lib/", "src/", "test/", "web/", "apps/"],
+        excluded: [~r"/_build/", ~r"/deps/", ~r"/node_modules/"]
+      },
+      #
+      # If you create your own checks, you must specify the source files for
+      # them here, so they can be loaded by Credo before running the analysis.
+      #
+      requires: [],
+      #
+      # If you want to enforce a style guide and need a more traditional linting
+      # experience, you can change `strict` to `true` below:
+      #
+      strict: false,
+      #
+      # If you want to use uncolored output by default, you can change `color`
+      # to `false` below:
+      #
+      color: true,
+      #
+      # You can customize the parameters of any check by adding a second element
+      # to the tuple.
+      #
+      # To disable a check put `false` as second element:
+      #
+      #     {Credo.Check.Design.DuplicatedCode, false}
+      #
+      checks: [
+        #
+        ## Consistency Checks
+        #
+        {Credo.Check.Consistency.ExceptionNames, []},
+        {Credo.Check.Consistency.LineEndings, []},
+        {Credo.Check.Consistency.ParameterPatternMatching, []},
+        {Credo.Check.Consistency.SpaceAroundOperators, []},
+        {Credo.Check.Consistency.SpaceInParentheses, []},
+        {Credo.Check.Consistency.TabsOrSpaces, []},
+
+        #
+        ## Design Checks
+        #
+        # You can customize the priority of any check
+        # Priority values are: `low, normal, high, higher`
+        #
+        {Credo.Check.Design.AliasUsage,
+         [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
+        # You can also customize the exit_status of each check.
+        # If you don't want TODO comments to cause `mix credo` to fail, just
+        # set this value to 0 (zero).
+        #
+        {Credo.Check.Design.TagTODO, [exit_status: 2]},
+        {Credo.Check.Design.TagFIXME, []},
+
+        #
+        ## Readability Checks
+        #
+        {Credo.Check.Readability.AliasOrder, []},
+        {Credo.Check.Readability.FunctionNames, []},
+        {Credo.Check.Readability.LargeNumbers, []},
+        {Credo.Check.Readability.MaxLineLength, [priority: :low, max_length: 120]},
+        {Credo.Check.Readability.ModuleAttributeNames, []},
+        {Credo.Check.Readability.ModuleDoc, []},
+        {Credo.Check.Readability.ModuleNames, []},
+        {Credo.Check.Readability.ParenthesesInCondition, []},
+        {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
+        {Credo.Check.Readability.PredicateFunctionNames, []},
+        {Credo.Check.Readability.PreferImplicitTry, []},
+        {Credo.Check.Readability.RedundantBlankLines, []},
+        {Credo.Check.Readability.Semicolons, []},
+        {Credo.Check.Readability.SpaceAfterCommas, []},
+        {Credo.Check.Readability.StringSigils, []},
+        {Credo.Check.Readability.TrailingBlankLine, []},
+        {Credo.Check.Readability.TrailingWhiteSpace, []},
+        # TODO: enable by default in Credo 1.1
+        {Credo.Check.Readability.UnnecessaryAliasExpansion, false},
+        {Credo.Check.Readability.VariableNames, []},
+
+        #
+        ## Refactoring Opportunities
+        #
+        {Credo.Check.Refactor.CondStatements, []},
+        {Credo.Check.Refactor.CyclomaticComplexity, []},
+        {Credo.Check.Refactor.FunctionArity, []},
+        {Credo.Check.Refactor.LongQuoteBlocks, []},
+        {Credo.Check.Refactor.MapInto, []},
+        {Credo.Check.Refactor.MatchInCondition, []},
+        {Credo.Check.Refactor.NegatedConditionsInUnless, []},
+        {Credo.Check.Refactor.NegatedConditionsWithElse, []},
+        {Credo.Check.Refactor.Nesting, []},
+        {Credo.Check.Refactor.PipeChainStart,
+         [
+           excluded_argument_types: [:atom, :binary, :fn, :keyword, :number],
+           excluded_functions: []
+         ]},
+        {Credo.Check.Refactor.UnlessWithElse, []},
+
+        #
+        ## Warnings
+        #
+        {Credo.Check.Warning.BoolOperationOnSameValues, []},
+        {Credo.Check.Warning.ExpensiveEmptyEnumCheck, []},
+        {Credo.Check.Warning.IExPry, []},
+        {Credo.Check.Warning.IoInspect, []},
+        {Credo.Check.Warning.LazyLogging, []},
+        {Credo.Check.Warning.OperationOnSameValues, []},
+        {Credo.Check.Warning.OperationWithConstantResult, []},
+        {Credo.Check.Warning.RaiseInsideRescue, []},
+        {Credo.Check.Warning.UnusedEnumOperation, []},
+        {Credo.Check.Warning.UnusedFileOperation, []},
+        {Credo.Check.Warning.UnusedKeywordOperation, []},
+        {Credo.Check.Warning.UnusedListOperation, []},
+        {Credo.Check.Warning.UnusedPathOperation, []},
+        {Credo.Check.Warning.UnusedRegexOperation, []},
+        {Credo.Check.Warning.UnusedStringOperation, []},
+        {Credo.Check.Warning.UnusedTupleOperation, []},
+
+        #
+        # Controversial and experimental checks (opt-in, just replace `false` with `[]`)
+        #
+        {Credo.Check.Consistency.MultiAliasImportRequireUse, false},
+        {Credo.Check.Design.DuplicatedCode, false},
+        {Credo.Check.Readability.Specs, false},
+        {Credo.Check.Refactor.ABCSize, false},
+        {Credo.Check.Refactor.AppendSingleItem, false},
+        {Credo.Check.Refactor.DoubleBooleanNegation, false},
+        {Credo.Check.Refactor.ModuleDependencies, false},
+        {Credo.Check.Refactor.VariableRebinding, false},
+        {Credo.Check.Warning.MapGetUnsafePass, false},
+        {Credo.Check.Warning.UnsafeToAtom, false}
+
+        #
+        # Custom checks can be created using `mix credo.gen.check`.
+        #
+      ]
+    }
+  ]
+}

--- a/.credo.exs
+++ b/.credo.exs
@@ -109,11 +109,7 @@
         {Credo.Check.Refactor.NegatedConditionsInUnless, []},
         {Credo.Check.Refactor.NegatedConditionsWithElse, []},
         {Credo.Check.Refactor.Nesting, []},
-        {Credo.Check.Refactor.PipeChainStart,
-         [
-           excluded_argument_types: [:atom, :binary, :fn, :keyword, :number],
-           excluded_functions: []
-         ]},
+        {Credo.Check.Refactor.PipeChainStart, false},
         {Credo.Check.Refactor.UnlessWithElse, []},
 
         #

--- a/lib/basic_types.ex
+++ b/lib/basic_types.ex
@@ -3,7 +3,6 @@ defmodule PropCheck.BasicTypes do
   This modules contains all basic type generators from PropEr. It is
   automatically available by `use PropCheck`.
 
-
   ## Acknowledgments
 
   The functions defined here are delegated to the corresponding
@@ -102,7 +101,6 @@ defmodule PropCheck.BasicTypes do
   @spec bitstring(non_neg_integer) :: type
   defdelegate bitstring(length), to: :proper_types
 
-
   @doc """
   A map whose keys are defined by the generator `k` and values by the generator `v`.
   """
@@ -116,7 +114,6 @@ defmodule PropCheck.BasicTypes do
   """
   @spec list(raw_type) :: type
   defdelegate list(elem_type), to: :proper_types
-
 
   @doc """
   A type that generates exactly the list `list`.
@@ -158,7 +155,6 @@ defmodule PropCheck.BasicTypes do
   @spec weighted_union([{frequency, raw_type},...]) :: type
   defdelegate weighted_union(list_of_types), to: :proper_types
 
-
   @doc """
   All tuples whose i-th element is an instance of the type at index i of
   `list_of_types`.
@@ -183,7 +179,6 @@ defmodule PropCheck.BasicTypes do
   """
   @spec exactly(any) :: type
   defdelegate exactly(value), to: :proper_types
-
 
   @doc """
   All lists whose i-th element is an instance of the type at index i of
@@ -259,7 +254,6 @@ defmodule PropCheck.BasicTypes do
   @doc "Char values (16 bit for some reason), i.e. `integer(0, 0xffff)`"
   @spec char() :: type
   def char, do: integer(0, 0xffff)
-
 
   @doc """
   Bounded upper size utf8 binary, `codepoint length =< MaxCodePointSize`.

--- a/lib/basic_types.ex
+++ b/lib/basic_types.ex
@@ -140,7 +140,7 @@ defmodule PropCheck.BasicTypes do
   instance of a type union to an instance of the first type in `list_of_types`,
   thus you should write the simplest case first.
   """
-  @spec union([raw_type,...]) :: type
+  @spec union([raw_type, ...]) :: type
   defdelegate union(list_of_types), to: :proper_types
 
   @doc """
@@ -152,7 +152,7 @@ defmodule PropCheck.BasicTypes do
   by the random instance generator. The shrinking subsystem will ignore the
   frequencies and try to shrink towards the first type in the list.
   """
-  @spec weighted_union([{frequency, raw_type},...]) :: type
+  @spec weighted_union([{frequency, raw_type}, ...]) :: type
   defdelegate weighted_union(list_of_types), to: :proper_types
 
   @doc """
@@ -289,7 +289,7 @@ defmodule PropCheck.BasicTypes do
   def char_list, do: list(char())
 
   @doc "weighted_union(FreqChoices)"
-  @spec wunion([{frequency,raw_type},...]) :: type
+  @spec wunion([{frequency, raw_type}, ...]) :: type
   def wunion(freq_choices), do: weighted_union(freq_choices)
 
   @doc "Term is a synonym for `any`"
@@ -344,15 +344,15 @@ defmodule PropCheck.BasicTypes do
   def choose(low, high), do: integer(low, high)
 
   @doc "elements is equivalent to `union([..])`"
-  @spec elements([raw_type,...]) :: type
+  @spec elements([raw_type, ...]) :: type
   def elements(choices), do: union(choices)
 
   @doc "oneof is equivalent to `union([..])`"
-  @spec oneof([raw_type,...]) :: type
+  @spec oneof([raw_type, ...]) :: type
   def oneof(choices), do: union(choices)
 
   @doc "frequency is equivalent to `weighted_union([..])`"
-  @spec frequency([{frequency,raw_type},...]) :: type
+  @spec frequency([{frequency, raw_type}, ...]) :: type
   def frequency(freq_choices), do: weighted_union(freq_choices)
 
   @doc "return is equivalent to `exactly`"
@@ -386,7 +386,7 @@ defmodule PropCheck.BasicTypes do
   shrinking subsystem will ignore the weights and try to shrink using the
   default value.
   """
-  @spec weighted_default({frequency,raw_type}, {frequency,raw_type}) :: type
+  @spec weighted_default({frequency, raw_type}, {frequency, raw_type}) :: type
   def weighted_default(default, type), do: weighted_union([default, type])
 
   @doc "A function with 0 parameters, i.e. `function(0, ret_type)`"
@@ -465,7 +465,7 @@ defmodule PropCheck.BasicTypes do
   """
   @spec with_parameter(atom, value, raw_type) :: type
   def with_parameter(parameter, value, type), do:
-      with_parameters([{parameter,value}], type)
+      with_parameters([{parameter, value}], type)
 
   @doc """
   Similar to `with_parameter/3`, but accepts a list of

--- a/lib/basic_types.ex
+++ b/lib/basic_types.ex
@@ -66,7 +66,7 @@ defmodule PropCheck.BasicTypes do
   Instances shrink towards the empty atom, `:""`.
   """
   @spec atom :: type
-  defdelegate atom(), to: :proper_types
+  defdelegate atom, to: :proper_types
 
   @doc """
   All binaries.
@@ -74,7 +74,7 @@ defmodule PropCheck.BasicTypes do
   Instances shrink towards the empty binary, `""`.
   """
   @spec binary() :: type
-  defdelegate binary(), to: :proper_types
+  defdelegate binary, to: :proper_types
 
   @doc """
   All binaries with a byte size of `length`.
@@ -91,7 +91,7 @@ defmodule PropCheck.BasicTypes do
   Instances shrink towards the empty bitstring, `""`.
   """
   @spec bitstring() :: type
-  defdelegate bitstring(), to: :proper_types
+  defdelegate bitstring, to: :proper_types
 
   @doc """
   All bitstrings with a bit size of `length`.
@@ -212,7 +212,7 @@ defmodule PropCheck.BasicTypes do
   type if you are certain that you need it.
   """
   @spec any() :: type
-  defdelegate any(), to: :proper_types
+  defdelegate any, to: :proper_types
 
   ################################################
   #
@@ -222,16 +222,16 @@ defmodule PropCheck.BasicTypes do
 
   @doc "All integers, i.e. `integer(:inf, :inf)`"
   @spec integer() :: type
-  def integer(), do: integer(:inf, :inf)
+  def integer, do: integer(:inf, :inf)
   @doc "Strictly positive integers, i.e. `integer(1, :inf)`"
   @spec pos_integer :: type
-  def pos_integer(), do: integer(1, :inf)
+  def pos_integer, do: integer(1, :inf)
   @doc "Non negative integers, i.e. `integer(0, :inf)`"
   @spec non_neg_integer :: type
-  def non_neg_integer(), do: integer(0, :inf)
+  def non_neg_integer, do: integer(0, :inf)
   @doc "Negative integers, i.e. `integer(:inf, -1)`"
   @spec neg_integer :: type
-  def neg_integer(), do: integer(:inf, -1)
+  def neg_integer, do: integer(:inf, -1)
 
   @doc "A range is equivalent to integers"
   @spec range(ext_int, ext_int) ::type
@@ -239,26 +239,26 @@ defmodule PropCheck.BasicTypes do
 
   @doc "All floats, i.e. `float(:inf, :inf)`"
   @spec float() :: type
-  def float(), do: float(:inf, :inf)
+  def float, do: float(:inf, :inf)
   @doc "Non negative floats, i.e. `float(0.0, inf)`"
   @spec non_neg_float() :: type
-  def non_neg_float(), do: float(0.0, :inf)
+  def non_neg_float, do: float(0.0, :inf)
 
   @doc "Numbers are integers or floats, i.e. `union([integer(), float()])`"
   @spec number() :: type
-  def number(), do: union([integer(), float()])
+  def number, do: union([integer(), float()])
 
   @doc "The atoms `true` and `false`. Instances shrink towards `false`."
   @spec boolean() :: type
-  def boolean(), do: union([false, true])
+  def boolean, do: union([false, true])
 
   @doc "Byte values, i.e. `integer(0, 255)`"
   @spec byte() :: type
-  def byte(), do: integer(0, 255)
+  def byte, do: integer(0, 255)
 
   @doc "Char values (16 bit for some reason), i.e. `integer(0, 0xffff)`"
   @spec char() :: type
-  def char(), do: integer(0, 0xffff)
+  def char, do: integer(0, 0xffff)
 
 
   @doc """
@@ -276,7 +276,7 @@ defmodule PropCheck.BasicTypes do
 
   @doc "utf8-encoded unbounded size binary"
   @spec utf8() :: type
-  def utf8(), do: utf8(:inf, 4)
+  def utf8, do: utf8(:inf, 4)
 
   @doc "utf8-encoded bounded upper size binary."
   @spec utf8(ext_non_neg_integer) :: type
@@ -284,15 +284,15 @@ defmodule PropCheck.BasicTypes do
 
   @doc "List of any types, i.e. `list(any)`"
   @spec list() :: type
-  def list(), do: list(any())
+  def list, do: list(any())
 
   @doc "Tuples of any types, i.e. `loose_tuple(any)`"
   @spec tuple() :: type
-  def tuple(), do: loose_tuple(any())
+  def tuple, do: loose_tuple(any())
 
   @doc "An Erlang string, i.e. `list(char)`"
   @spec char_list() :: type
-  def char_list(), do: list(char())
+  def char_list, do: list(char())
 
   @doc "weighted_union(FreqChoices)"
   @spec wunion([{frequency,raw_type},...]) :: type
@@ -300,15 +300,15 @@ defmodule PropCheck.BasicTypes do
 
   @doc "Term is a synonym for `any`"
   @spec term() :: type
-  def term(), do: any()
+  def term, do: any()
 
   @doc "timeout values, i.e. `union([non_neg_integer() | :infinity])`"
   @spec timeout() :: type
-  def timeout(), do: union([non_neg_integer(), :infinity])
+  def timeout, do: union([non_neg_integer(), :infinity])
 
   @doc "Arity is a byte value, i.e. `integer(0, 255)`"
   @spec arity() :: type
-  def arity(), do: integer(0, 255)
+  def arity, do: integer(0, 255)
 
   ################################################
   #
@@ -322,7 +322,7 @@ defmodule PropCheck.BasicTypes do
   Instances shrink towards `0`.
   """
   @spec int() :: type
-  def int(), do: sized(size, integer(-size, size))
+  def int, do: sized(size, integer(-size, size))
 
   @doc """
   Small Small non-negative integers (bound by the current value of the `size`
@@ -331,19 +331,19 @@ defmodule PropCheck.BasicTypes do
   Instances shrink towards `0`.
   """
   @spec nat() :: type
-  def nat(), do: sized(size, integer(0, size))
+  def nat, do: sized(size, integer(0, size))
 
   @doc "Large_int is equivalent to `integer`"
   @spec large_int() :: type
-  def large_int(), do: integer()
+  def large_int, do: integer()
 
   @doc "real is equivalent to `float`"
   @spec real() :: type
-  def real(), do: float()
+  def real, do: float()
 
   @doc "bool is equivalent to `boolean`"
   @spec bool() :: type
-  def bool(), do: boolean()
+  def bool, do: boolean()
 
   @doc "choose is equivalent to `integer(low, high)`"
   @spec choose(ext_int, ext_int) :: type

--- a/lib/counterstrike.ex
+++ b/lib/counterstrike.ex
@@ -17,7 +17,7 @@ defmodule PropCheck.CounterStrike do
 
   defstruct [counter_examples: %{}, dets: nil]
 
-  def start_link(filename \\ 'propcheck.dets', opts \\[])
+  def start_link(filename \\ 'propcheck.dets', opts \\ [])
   def start_link(filename, opts) when is_binary(filename), do: start_link(String.to_charlist(filename), opts)
   def start_link(filename, opts) when is_list(filename) do
     # Logger.info "Filename: #{filename}, options: #{inspect opts}"

--- a/lib/counterstrike.ex
+++ b/lib/counterstrike.ex
@@ -67,7 +67,7 @@ defmodule PropCheck.CounterStrike do
 
   defp check_counter_example(counter_examples, mfa) do
     # Logger.debug "#{inspect self()}: Asked for mfa #{inspect mfa} in #{inspect counter_examples}"
-    if (Enum.count(counter_examples) == 0) do
+    if Enum.empty?(counter_examples) do
       :none
     else
       case Map.fetch(counter_examples, mfa) do

--- a/lib/fsm.ex
+++ b/lib/fsm.ex
@@ -122,7 +122,6 @@ defmodule PropCheck.FSM do
   @type command  :: {:set ,symb_var,symb_call} | {:init, fsm_state()}
   @type command_list:: [command]
 
-
   @doc """
   Specifies the initial state of the finite state machine. As with
   `c:PropCheck.StateM.initial_state/0`, its result should be deterministic.

--- a/lib/fsm.ex
+++ b/lib/fsm.ex
@@ -114,12 +114,12 @@ defmodule PropCheck.FSM do
   @type symb_var :: PropCheck.StateM.symb_var
   @type fsm_state()    :: {state_name, state_data}
   @type transition()   :: {state_name, symb_call}
-  @type history()      :: [{fsm_state,cmd_result}]
+  @type history()      :: [{fsm_state, cmd_result}]
 
   @type result :: :proper_statem.statem_result
   @type fsm_result :: result
   @type cmd_result :: any
-  @type command  :: {:set ,symb_var,symb_call} | {:init, fsm_state()}
+  @type command  :: {:set, symb_var, symb_call} | {:init, fsm_state()}
   @type command_list:: [command]
 
   @doc """
@@ -211,7 +211,7 @@ defmodule PropCheck.FSM do
   The result is a triple of the form `{history, fsm_state, result}`,
   similar to `PropCheck.StateM.run_commands/2`.
   """
-  @spec run_commands(mod_name, command_list) :: {history,fsm_state,fsm_result}
+  @spec run_commands(mod_name, command_list) :: {history, fsm_state, fsm_result}
   def run_commands(mod, cmds), do: :proper_fsm.run_commands(mod, cmds)
 
   @doc """
@@ -220,7 +220,7 @@ defmodule PropCheck.FSM do
   `PropCheck.StateM.run_commands/3`.
   """
   @spec run_commands(mod_name, command_list, :proper_symb.var_values) ::
-           {history,fsm_state,fsm_result}
+           {history, fsm_state, fsm_result}
   def run_commands(mod, cmds, env), do: :proper_fsm.run_commands(mod, cmds, env)
 
   @doc """

--- a/lib/mix.ex
+++ b/lib/mix.ex
@@ -31,9 +31,11 @@ defmodule Mix.Tasks.Propcheck do
   with `mix propcheck.clean` the file is deleted afterwards.
   """
 
+  alias Mix.Tasks.Help
+
   def run(_) do
     Mix.shell.info("Available PropCheck tasks:\n")
-    Mix.Tasks.Help.run(["--search", "propcheck."])
+    Help.run(["--search", "propcheck."])
   end
 
   defmodule Clean do

--- a/lib/mix.ex
+++ b/lib/mix.ex
@@ -1,7 +1,7 @@
 defmodule PropCheck.Mix do
   @moduledoc false
 
-  def counter_example_file() do
+  def counter_example_file do
     default_path =
       Mix.Project.build_path()
       |> Path.dirname()

--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -788,14 +788,14 @@ defmodule PropCheck do
     the most recent testing run.
     """
     @spec counterexample() :: counterexample | :undefined
-    def counterexample(), do: :erlang.get(:"$counterexample")
+    def counterexample, do: :erlang.get(:"$counterexample")
 
     @doc """
     Returns a counterexample for each failing property of the most recent
     module testing run.
     """
     @spec counterexamples() :: [{mfa,counterexample}] | :undefined
-    def counterexamples(), do: :erlang.get(:"$counterexamples")
+    def counterexamples, do: :erlang.get(:"$counterexamples")
 
     @doc "Runs PropEr on the property `outer_test`."
     @spec quickcheck(outer_test) :: result

--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -955,7 +955,6 @@ defmodule PropCheck do
         a === b, IO.puts("#{inspect a, [pretty: true]} != #{inspect b, [pretty: true]}"))
     end
 
-
     @doc """
     A predefined function that accepts an atom or string and returns a
     stats printing function which is equivalent to the default one, but prints

--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -580,7 +580,7 @@ defmodule PropCheck do
             fn(unquote(vars)) -> unquote(gen) end, false)
         end
     end
-    defp let_bind({:<-, _, [var, rawtype]} = _bind), do: {var, rawtype}
+    defp let_bind(_bind = {:<-, _, [var, rawtype]}), do: {var, rawtype}
     defp let_bind([{:<-, _, [var, rawtype]}]) do
       [{var, rawtype}]
     end

--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -286,7 +286,7 @@ defmodule PropCheck do
     @type user_opts :: [user_opt] | user_opt
     @type outer_test :: :proper.outer_test
     @type test :: :proper.test
-    @type output_fun :: ((charlist,[term]) -> :ok)
+    @type output_fun :: ((charlist, [term]) -> :ok)
     @type size :: non_neg_integer
     @type user_opt :: :quiet
       | :verbose
@@ -317,7 +317,7 @@ defmodule PropCheck do
     @type long_result :: :true | counterexample | error
     @type short_result :: boolean | error
     @type result :: long_result | short_result
-    @type long_module_result :: [{mfa,counterexample}] | error
+    @type long_module_result :: [{mfa, counterexample}] | error
     @type short_module_result :: [mfa] | error
     @type module_result :: long_module_result | short_module_result
 
@@ -402,7 +402,7 @@ defmodule PropCheck do
         iex> require Integer
         iex> quickcheck(
         ...> forall n <- nat() do
-        ...>    implies rem(n,2) == 0, do: Integer.is_even n
+        ...>    implies rem(n, 2) == 0, do: Integer.is_even n
         ...> end
         ...>)
         true
@@ -794,7 +794,7 @@ defmodule PropCheck do
     Returns a counterexample for each failing property of the most recent
     module testing run.
     """
-    @spec counterexamples() :: [{mfa,counterexample}] | :undefined
+    @spec counterexamples() :: [{mfa, counterexample}] | :undefined
     def counterexamples, do: :erlang.get(:"$counterexamples")
 
     @doc "Runs PropEr on the property `outer_test`."

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -7,7 +7,6 @@ defmodule PropCheck.Properties do
   alias PropCheck.CounterStrike
   require Logger
 
-
   @doc """
   Defines a property as part of an ExUnit test.
 

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -83,14 +83,14 @@ defmodule PropCheck.Properties do
     should_fail = is_tuple(p) and elem(p, 0) == :fails
     # Logger.debug "Execute property #{inspect name} "
     case CounterStrike.counter_example(name) do
-      :none -> PropCheck.quickcheck(p, [:long_result] ++opts)
+      :none -> PropCheck.quickcheck(p, [:long_result] ++ opts)
       :others ->
         # since the tag is set, we execute everything. You can limit
         # the amount of checks by using either --stale or --only failing_prop
         qc(p, opts)
       {:ok, counter_example} ->
         # Logger.debug "Found counter example #{inspect counter_example}"
-        result = PropCheck.check(p, counter_example, [:long_result] ++opts)
+        result = PropCheck.check(p, counter_example, [:long_result] ++ opts)
         with true <- result do
           qc(p, opts)
         else

--- a/lib/result.ex
+++ b/lib/result.ex
@@ -9,7 +9,7 @@ defmodule PropCheck.Result do
   @type t :: %__MODULE__{tests: [any], errors: [any], current: nil | atom}
 
   def start_link do
-    :gen_server.start_link({ :local, __MODULE__ }, __MODULE__, [], [])
+    :gen_server.start_link({:local, __MODULE__}, __MODULE__, [], [])
   end
   def stop do
     :gen_server.call(__MODULE__, :stop)
@@ -26,7 +26,7 @@ defmodule PropCheck.Result do
 
  @spec init(any) :: {:ok, t}
  def init(_args) do
-    { :ok, %__MODULE__{} }
+    {:ok, %__MODULE__{}}
   end
 
   @spec handle_call({:message, any, any}, {pid, any}, t) :: {:reply, :ok, t}
@@ -41,13 +41,13 @@ defmodule PropCheck.Result do
       :lists.prefix('Testing', fmt) ->
         %__MODULE__{state | tests: [args | state.tests], current: args}
     end
-    { :reply, :ok, state }
+    {:reply, :ok, state}
   end
 
   def handle_call(:status, _from, state) do
-    { :reply, {state.tests, state.errors} , state }
+    {:reply, {state.tests, state.errors} , state}
   end
   def handle_call(:stop, _from, state) do
-    { :stop, :normal, :ok, state }
+    {:stop, :normal, :ok, state}
   end
 end

--- a/lib/result.ex
+++ b/lib/result.ex
@@ -12,11 +12,9 @@ defmodule PropCheck.Result do
     :gen_server.start_link({ :local, __MODULE__ }, __MODULE__, [], [])
   end
   def stop do
-    try do
-      :gen_server.call(__MODULE__, :stop)
-    catch
-      _ -> :ok
-    end
+    :gen_server.call(__MODULE__, :stop)
+  catch
+    _ -> :ok
   end
   def status do
     :gen_server.call(__MODULE__, :status)

--- a/lib/statem.ex
+++ b/lib/statem.ex
@@ -12,7 +12,6 @@ defmodule PropCheck.StateM do
   failure, the shrinking mechanism attempts to find a minimal sequence of
   calls provoking the same error.
 
-
   ## The role of commands
 
   Test cases generated for testing a stateful system are lists of symbolic API
@@ -63,7 +62,6 @@ defmodule PropCheck.StateM do
      dynamic state. After running the previous command sequence, the model state
     will be `[b: 42]`.
 
-
   ## The callback functions
 
   The following functions must be exported from the callback module
@@ -74,7 +72,6 @@ defmodule PropCheck.StateM do
    * `c:precondition/2`
    * `c:postcondition/3`
    * `c:next_state/3`
-
 
   ## The property used
 
@@ -88,7 +85,6 @@ defmodule PropCheck.StateM do
     `run_commands/2`, a function that evaluates a symbolic command
     sequence according to an abstract state machine specification.
 
-
   These two phases are encapsulated in the following property, which can be
   used for testing the process dictionary:
 
@@ -99,7 +95,6 @@ defmodule PropCheck.StateM do
           result == ok
         end
       end
-
 
   When testing impure code, it is very important to keep each test
   self-contained. For this reason, almost every property for testing stateful

--- a/lib/statem.ex
+++ b/lib/statem.ex
@@ -172,7 +172,7 @@ defmodule PropCheck.StateM do
   @type dynamic_state :: any
   @type symb_call :: :proper_statem.symb_call
   @type command :: :proper_statem.command
-  @type parallel_testcase :: {command_list,[command_list]}
+  @type parallel_testcase :: {command_list, [command_list]}
   @type command_list :: [command]
 
   @doc """

--- a/lib/statem_dsl.ex
+++ b/lib/statem_dsl.ex
@@ -313,7 +313,7 @@ defmodule PropCheck.StateM.DSL do
     do
       new_name = String.to_atom("#{name}_#{suffix_name}")
       # Logger.error "Found suffix: #{new_name}"
-      {:def, c1,[{new_name, c2, args}, body]}
+      {:def, c1, [{new_name, c2, args}, body]}
     end
   defp rename_def_in_command(ast, _name) do
     # Logger.warn "Found ast = #{inspect ast}"

--- a/lib/statem_dsl.ex
+++ b/lib/statem_dsl.ex
@@ -485,7 +485,10 @@ defmodule PropCheck.StateM.DSL do
 
   # replaces all symbolic variables of form `{:var, n}` with
   # the value in `env` (i.e. mapping of symbolic vars to values)
-  @spec replace_symb_vars(symbolic_call | symbolic_var | [symbolic_call | symbolic_var] | any, environment) :: symbolic_call
+  @spec replace_symb_vars(
+          symbolic_call | symbolic_var | [symbolic_call | symbolic_var] | any,
+          environment
+        ) :: symbolic_call
   defp replace_symb_vars({:call, m, f, args}, env) do
     replaced_m = replace_symb_vars(m, env)
     replaced_f = replace_symb_vars(f, env)

--- a/lib/statem_dsl.ex
+++ b/lib/statem_dsl.ex
@@ -252,7 +252,6 @@ defmodule PropCheck.StateM.DSL do
   @callback weight(symbolic_state) :: %{required(command_name) => pos_integer}
   @optional_callbacks weight: 1
 
-
   defmacro __using__(_options) do
     quote do
       import unquote(__MODULE__)
@@ -556,7 +555,6 @@ defmodule PropCheck.StateM.DSL do
       {m, f, length(args)}
     end)
   end
-
 
   # Detects alls commands within `mod_bin_code`, i.e. all functions with the
   # same prefix and a suffix `_command` or `_args` and a prefix `_next`.

--- a/lib/statem_dsl.ex
+++ b/lib/statem_dsl.ex
@@ -263,7 +263,7 @@ defmodule PropCheck.StateM.DSL do
 
   defmacro __before_compile__(_env) do
     quote do
-      def __all_commands__(), do: @commands
+      def __all_commands__, do: @commands
     end
   end
 

--- a/lib/targeted.ex
+++ b/lib/targeted.ex
@@ -67,7 +67,6 @@ defmodule PropCheck.TargetedPBT do
         end
       end
 
-
   ## How the targeted properties relate
 
   The targeted macros `forall_targeted`, `exists` and `not_exists` are related to each other.
@@ -87,7 +86,6 @@ defmodule PropCheck.TargetedPBT do
 
       not_exists x <- x_gen(), do: p(x)
          <==> forall_targeted x <- x_gen(), do: not(p(x))
-
 
   ## Options
 
@@ -201,7 +199,6 @@ defmodule PropCheck.TargetedPBT do
       :proper_target.targeted(make_ref(), tmap_val)
     end
   end
-
 
   # For backward compatibility with the scientific papers.
   # -define(STRATEGY(Strat, Prop), ?SETUP(fun (Opts) ->

--- a/mix.exs
+++ b/mix.exs
@@ -68,7 +68,8 @@ defmodule Propcheck.Mixfile do
       {:coverex, "~> 1.4.15", only: :test},
       {:ex_doc, "~>0.16", only: :dev},
       {:earmark, ">= 0.2.1", only: :dev},
-      {:proper, "~> 1.3"}
+      {:proper, "~> 1.3"},
+      {:credo, "~> 1.0.0", only: [:dev, :test], runtime: false}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,8 @@
 %{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "coverex": {:hex, :coverex, "1.4.15", "60fadf825a6c0439b79d1f98cdb54b6733cdd5cb1b35d15d56026c44ed15a5a8", [:mix], [{:hackney, "~> 1.5", [hex: :hackney, repo: "hexpm", optional: false]}, {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "credo": {:hex, :credo, "1.0.3", "5278e8953f379b41ebe27c75c96d2e154ebc3f75dfe057c8b68c39133c25bb9f", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "dialyze": {:hex, :dialyze, "0.2.0", "ecabf292e9f4bd0f7d844981f899a85c0300b30ff2dd1cdfef0c81a6496466f1", [:mix], []},
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
@@ -8,6 +10,7 @@
   "hackney": {:hex, :hackney, "1.15.1", "9f8f471c844b8ce395f7b6d8398139e26ddca9ebc171a8b91342ee15a19963f4", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "0.8.3", "b675a3fdc839a0b8d7a285c6b3747d6d596ae70b6ccb762233a990d7289ccae4", [:mix], [{:hackney, "~> 1.6.0", [hex: :hackney, optional: false]}]},
   "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},

--- a/test/basic_types_test.exs
+++ b/test/basic_types_test.exs
@@ -8,7 +8,7 @@ defmodule PropCheck.Test.BasicTypes do
   # Symbolic calls
   # as explained in http://propertesting.com/book_custom_generators.html#_symbolic_calls
   # work also in PropCheck.
-  def dict_autosymb(), do:
+  def dict_autosymb, do:
     sized(size, dict_autosymb(size, {:"$call", :dict, :new, []}))
   def dict_autosymb(0, dict), do: dict
   def dict_autosymb(n, dict), do:

--- a/test/basic_types_test.exs
+++ b/test/basic_types_test.exs
@@ -12,7 +12,7 @@ defmodule PropCheck.Test.BasicTypes do
     sized(size, dict_autosymb(size, {:"$call", :dict, :new, []}))
   def dict_autosymb(0, dict), do: dict
   def dict_autosymb(n, dict), do:
-    dict_autosymb(n-1, {:"$call", :dict, :store, [integer(), integer(), dict]})
+    dict_autosymb(n - 1, {:"$call", :dict, :store, [integer(), integer(), dict]})
 
   property "symbolic auto calls on dict - expected to fail" do
     forall d <- dict_autosymb() do

--- a/test/cache_dsl_test.exs
+++ b/test/cache_dsl_test.exs
@@ -10,7 +10,6 @@ defmodule PropCheck.Test.Cache.DSL do
   alias PropCheck.Test.Cache
   # require Logger
 
-
   @cache_size 10
 
   property "run the sequential cache", [:verbose] do
@@ -77,7 +76,6 @@ defmodule PropCheck.Test.Cache.DSL do
     |> Enum.map(fn {state, _call, _result} -> state end)
   end
 
-
   ###########################
   # Testing the command generators and such
 
@@ -118,7 +116,6 @@ defmodule PropCheck.Test.Cache.DSL do
   ##################
   # The command weight distribution
   def weight(_state), do: %{find: 1, cache: 3, flush: 1}
-
 
   ###### Command: find
 
@@ -167,7 +164,6 @@ defmodule PropCheck.Test.Cache.DSL do
     # pre condition: do not call flush() twice
     def pre(%__MODULE__{count: c}, _args), do: c != 0
   end
-
 
   defp update_entries(s = %__MODULE__{}, l) do
     %__MODULE__{s | entries: l, count: Enum.count(l)}

--- a/test/cache_dsl_test.exs
+++ b/test/cache_dsl_test.exs
@@ -104,16 +104,16 @@ defmodule PropCheck.Test.Cache.DSL do
   code related to key reuse or matching, but without losing the ability
   to 'fuzz' the system.
   """
-  def key(), do: oneof([
+  def key, do: oneof([
     integer(1, @cache_size),
     integer()
     ])
   @doc "our values are integers"
-  def val(), do: integer()
+  def val, do: integer()
 
   ###################
   # the initial state of our model
-  def initial_state(), do: %__MODULE__{}
+  def initial_state, do: %__MODULE__{}
 
   ##################
   # The command weight distribution
@@ -159,7 +159,7 @@ defmodule PropCheck.Test.Cache.DSL do
 
   defcommand :flush do
     # implement flush
-    def impl(), do: Cache.flush()
+    def impl, do: Cache.flush()
     # next state is: cache is empty
     def next(state, _args, _res) do
       update_entries(state, [])

--- a/test/cache_dsl_test.exs
+++ b/test/cache_dsl_test.exs
@@ -140,7 +140,7 @@ defmodule PropCheck.Test.Cache.DSL do
     # generator for args of cache
     def args(_state), do: [key(), val()]
     # what is the next state?
-    def next(s=%__MODULE__{entries: l, count: n, max: m}, [k, v], _res) do
+    def next(s = %__MODULE__{entries: l, count: n, max: m}, [k, v], _res) do
       case List.keyfind(l, k, 0, false) do
           # When the cache is at capacity, the first element is dropped (tl(L))
           # before adding the new one at the end

--- a/test/counter_dsl_test.exs
+++ b/test/counter_dsl_test.exs
@@ -90,13 +90,13 @@ defmodule PropCheck.Test.CounterDSL do
   ### The model
   #########################################################################
 
-  def initial_state(), do: :init
+  def initial_state, do: :init
 
   def weight(:init), do: %{inc: 1, clear: 1}
   def weight(_), do: %{get: 1, inc: 2, clear: 1}
 
   defcommand :inc do
-    def impl(), do: Counter.inc()
+    def impl, do: Counter.inc()
     def args(_), do: []
     def next(:init, [], _res), do: :zero
     def next(:zero, [], _res), do: :one
@@ -107,7 +107,7 @@ defmodule PropCheck.Test.CounterDSL do
   end
 
   defcommand :get do
-    def impl(), do: Counter.get()
+    def impl, do: Counter.get()
     def args(_), do: []
     def post(_state, [], res), do: res >= 0
     def pre(:init, _, _), do: false
@@ -115,7 +115,7 @@ defmodule PropCheck.Test.CounterDSL do
   end
 
   defcommand :clear do
-    def impl(), do: Counter.clear()
+    def impl, do: Counter.clear()
     def args(_), do: []
     def next(_state, [], _res), do: :zero
     def post(_state, [], res), do: res == :ok

--- a/test/let_test.exs
+++ b/test/let_test.exs
@@ -168,5 +168,4 @@ defmodule PropCheck.Test.LetAndShrinks do
 
   end
 
-
 end

--- a/test/let_test.exs
+++ b/test/let_test.exs
@@ -9,7 +9,7 @@ defmodule PropCheck.Test.LetAndShrinks do
     end
   end
 
-  def kilo_numbers() do
+  def kilo_numbers do
     let [num <- integer(1, 1000)] do
       num
     end
@@ -28,7 +28,7 @@ defmodule PropCheck.Test.LetAndShrinks do
     use PropCheck
     use PropCheck.StateM.DSL
 
-    def initial_state(), do: %{}
+    def initial_state, do: %{}
 
     defcommand :equal do
       def impl(_number), do: :ok
@@ -60,7 +60,7 @@ defmodule PropCheck.Test.LetAndShrinks do
     use PropCheck
     use PropCheck.StateM.DSL
 
-    def initial_state(), do: %{}
+    def initial_state, do: %{}
 
     defcommand :equal do
       def impl(_number), do: :ok
@@ -97,9 +97,9 @@ defmodule PropCheck.Test.LetAndShrinks do
     use PropCheck
     use PropCheck.StateM
 
-    def initial_state(), do: %{}
+    def initial_state, do: %{}
 
-    def args() do
+    def args do
       let ([num <- integer(1, 1000)]) do
         [num]
       end
@@ -136,7 +136,7 @@ defmodule PropCheck.Test.LetAndShrinks do
     use PropCheck
     use PropCheck.StateM.DSL
 
-    def initial_state(), do: %{}
+    def initial_state, do: %{}
 
     defcommand :equal do
       def impl(_number), do: :ok

--- a/test/level_tpbt_test.exs
+++ b/test/level_tpbt_test.exs
@@ -94,7 +94,6 @@ defmodule PropCheck.Test.LevelTest do
   #                  end
   #              end).
 
-
   # This property uses `forall_targeted`, therefore the condition checked inside
   # the property is negated and it must be negated outside (see docs of `prop_exit/1` for
   # more details).
@@ -140,7 +139,6 @@ defmodule PropCheck.Test.LevelTest do
   #                            true
   #                        end
   #                    end).
-
 
   def prop_forall_targeted(level_data) do
     level = Level.build_level(level_data)
@@ -217,6 +215,5 @@ defmodule PropCheck.Test.LevelTest do
       end
     end
   end
-
 
 end

--- a/test/level_tpbt_test.exs
+++ b/test/level_tpbt_test.exs
@@ -11,14 +11,14 @@ defmodule PropCheck.Test.LevelTest do
   # Generators
   #######################################################################
 
-  def step(), do: oneof([:left, :right, :up, :down])
+  def step, do: oneof([:left, :right, :up, :down])
 
-  def path_gen(), do: list(step())
+  def path_gen, do: list(step())
 
-  def path_gen_sa(), do: %{first: path_gen(), next: path_next()}
+  def path_gen_sa, do: %{first: path_gen(), next: path_next()}
 
   @spec path_next() :: ([Level.step], any() -> PropCheck.BasicTypes.t)
-  def path_next() do
+  def path_next do
     fn
       (prev_path, _temperature) when is_list(prev_path) ->
         let next_steps <- vector(20, step()), do:

--- a/test/level_tpbt_test.exs
+++ b/test/level_tpbt_test.exs
@@ -100,7 +100,7 @@ defmodule PropCheck.Test.LevelTest do
   # When using a proper-derived generator, we might have to search longer to find
   # a successful path. Therefore, we increase the amount of search_steps. For more complex
   # situations, e.g. for level 2, the size of the generated paths may become larger.
-  property "Target PBT Level 1 with forall_targeted and proper-derived nf", [:verbose, search_steps: 2_0000] do
+  property "Target PBT Level 1 with forall_targeted and proper-derived nf", [:verbose, search_steps: 20_000] do
     level_data = Level.level1()
     level = Level.build_level(level_data)
     %{entrance: entrance} = level

--- a/test/master_statem_test.exs
+++ b/test/master_statem_test.exs
@@ -33,7 +33,7 @@ defmodule PropCheck.Test.MasterStateM do
   end
 
   # ensure all player processes are dead
-  defp kill_all_player_processes() do
+  defp kill_all_player_processes do
     require Logger
     Process.registered
     |> Enum.filter(&(Atom.to_string(&1) |> String.starts_with?("player_")))
@@ -63,7 +63,7 @@ defmodule PropCheck.Test.MasterStateM do
   @max_players 100
   @players 1..@max_players |> Enum.map(&("player_#{&1}") |> String.to_atom)
 
-  def name(), do: oneof @players
+  def name, do: oneof @players
 
   def command(players) do
     if (Enum.count(players) > 0) do
@@ -86,7 +86,7 @@ defmodule PropCheck.Test.MasterStateM do
   #####################################################
 
   @doc "initial model state of the state machine"
-  def initial_state(), do: MapSet.new
+  def initial_state, do: MapSet.new
 
   @doc """
   Update the model state after a successful call. The `state` parameter has

--- a/test/movie_dsl_test.exs
+++ b/test/movie_dsl_test.exs
@@ -44,7 +44,7 @@ defmodule PropCheck.Test.MoviesDSL do
   defstruct users: [], rented: %{}
 
   @doc "Initialize the model"
-  def initial_state(), do: %__MODULE__{}
+  def initial_state, do: %__MODULE__{}
 
 
   #########################################################################
@@ -96,10 +96,10 @@ defmodule PropCheck.Test.MoviesDSL do
   @movie_titles Keyword.keys(@available_movies) ++ [:titanic, :inception]
 
   @doc "generator for name"
-  def name(), do: oneof @names
+  def name, do: oneof @names
 
   @doc "generator for movies"
-  def movie(), do: oneof @movie_titles
+  def movie, do: oneof @movie_titles
 
 
   @doc """
@@ -160,7 +160,7 @@ defmodule PropCheck.Test.MoviesDSL do
   end
 
   defcommand :ask_for_popcorn do
-    def impl(), do: MovieServer.ask_for_popcorn()
+    def impl, do: MovieServer.ask_for_popcorn()
     def post(_state, [], result), do: result == :bon_appetit
   end
 

--- a/test/movie_dsl_test.exs
+++ b/test/movie_dsl_test.exs
@@ -46,7 +46,6 @@ defmodule PropCheck.Test.MoviesDSL do
   @doc "Initialize the model"
   def initial_state, do: %__MODULE__{}
 
-
   #########################################################################
   ### Test local preconditions, helpers and the like
   #########################################################################
@@ -56,7 +55,6 @@ defmodule PropCheck.Test.MoviesDSL do
     Logger.debug "test u_m_p: #{inspect s}"
     assert [{{:var, 1}, :mary_poppins}] == user_movie_pairs(s)
   end
-
 
   #########################################################################
   ### Weights of the commands
@@ -75,7 +73,6 @@ defmodule PropCheck.Test.MoviesDSL do
       std_commands
     end
   end
-
 
   #########################################################################
   ### Value generators
@@ -100,7 +97,6 @@ defmodule PropCheck.Test.MoviesDSL do
 
   @doc "generator for movies"
   def movie, do: oneof @movie_titles
-
 
   @doc """
   Generate only valid passwords, i.e those from existing users.

--- a/test/movie_test.exs
+++ b/test/movie_test.exs
@@ -162,18 +162,18 @@ defmodule PropCheck.Test.Movies do
   def precondition(_state, _call), do: true
 
   @doc "Postconditions ensure that the expected effect has taken place"
-  def postcondition(%__MODULE__{users: users}, {:call, _, :create_account,[_name]}, result) do
+  def postcondition(%__MODULE__{users: users}, {:call, _, :create_account, [_name]}, result) do
     # the new user was formerly not available
     not (users |> Enum.member?(result))
   end
-  def postcondition(%__MODULE__{rented: rented}, {:call, _, :delete_account,[passwd]}, result) do
+  def postcondition(%__MODULE__{rented: rented}, {:call, _, :delete_account, [passwd]}, result) do
     # deletion does not work always
     case rented |> Map.get(passwd, []) do
       [] -> result == :account_deleted
       _any_movie ->  result == :return_movies_first
     end
   end
-  def postcondition(state, {:call, _, :rent_dvd,[passwd, movie]}, result) do
+  def postcondition(state, {:call, _, :rent_dvd, [passwd, movie]}, result) do
     # if the movie exists, then it must there, otherwise not
     case is_available(state, movie) do
       true ->

--- a/test/movie_test.exs
+++ b/test/movie_test.exs
@@ -190,7 +190,6 @@ defmodule PropCheck.Test.Movies do
     result == :bon_appetit
   end
 
-
   @doc "is the movie available?"
   def is_available(%__MODULE__{rented: rented}, movie) do
     max_av = @available_movies |> Keyword.get(movie, -1)

--- a/test/movie_test.exs
+++ b/test/movie_test.exs
@@ -58,10 +58,10 @@ defmodule PropCheck.Test.Movies do
   @movie_titles (@available_movies |> Keyword.keys) ++ [:titanic, :inception]
 
   @doc "generator for name"
-  def name(), do: elements @names
+  def name, do: elements @names
 
   @doc "generator for movies"
-  def movie(), do: elements @movie_titles
+  def movie, do: elements @movie_titles
 
   # The state of the state machine
   # first components holds the return value of create_account,
@@ -125,7 +125,7 @@ defmodule PropCheck.Test.Movies do
   end
 
   @doc "Initialize the model"
-  def initial_state(), do: %__MODULE__{}
+  def initial_state, do: %__MODULE__{}
 
   @doc "The state machine entries"
   def next_state(s = %__MODULE__{users: users}, v, {:call, _, :create_account, [_name]}), do:

--- a/test/movie_test.exs
+++ b/test/movie_test.exs
@@ -99,7 +99,7 @@ defmodule PropCheck.Test.Movies do
       {1, {:call, MovieServer, :rent_dvd, [password(state), movie()]}}]
 
     calls =
-      if (movies_rented) do
+      if movies_rented do
         pms = user_movie_pairs(rented)
         #IO.puts "User/movie pairs: #{inspect pms}"
         [{5, let {p, m} <- elements(pms) do

--- a/test/pingpong_dsl_test.exs
+++ b/test/pingpong_dsl_test.exs
@@ -31,7 +31,7 @@ defmodule PropCheck.Test.PingPongDSL do
   end
 
   @spec player_processes() :: [String.t]
-  defp player_processes() do
+  defp player_processes do
     Process.registered
     |> Enum.filter(&(Atom.to_string(&1)
     |> String.starts_with?("player_")))
@@ -47,7 +47,7 @@ defmodule PropCheck.Test.PingPongDSL do
   defstruct players: [], scores: %{}
 
   @doc "initial model state of the state machine"
-  def initial_state(), do: %__MODULE__{}
+  def initial_state, do: %__MODULE__{}
 
   def weight(%__MODULE__{players: []}), do: %{add_player: 1}
   def weight(_), do:
@@ -66,7 +66,7 @@ defmodule PropCheck.Test.PingPongDSL do
     |> Enum.map(&("player_#{&1}")
     |> String.to_atom)
 
-  def any_name(), do: elements @players
+  def any_name, do: elements @players
   def known_name(%__MODULE__{players: player_list}), do: elements player_list
 
   defcommand :add_player do

--- a/test/pingpong_dsl_test.exs
+++ b/test/pingpong_dsl_test.exs
@@ -94,7 +94,7 @@ defmodule PropCheck.Test.PingPongDSL do
       |> Map.put(:players, List.delete(ps, name))
       |> Map.put(:scores, Map.delete(scores, name))
     end
-    def pre(%__MODULE{players: ps}, [name]), do: Enum.member?(ps, name)
+    def pre(%__MODULE__{players: ps}, [name]), do: Enum.member?(ps, name)
   end
 
   defcommand :play_ping_pong do

--- a/test/pingpong_fsm_test.exs
+++ b/test/pingpong_fsm_test.exs
@@ -85,7 +85,7 @@ defmodule PropCheck.Test.PingPongFSM do
   end
 
   # no specific preconditions
-  def precondition(_from, _target, _state, {:call, _m, _f, _a,}), do: true
+  def precondition(_from, _target, _state, {:call, _m, _f, _a}), do: true
 
   # imprecise get_score due to async play-functions
   def postcondition(_from, _target, %__MODULE__{scores: scores},

--- a/test/pingpong_fsm_test.exs
+++ b/test/pingpong_fsm_test.exs
@@ -53,7 +53,6 @@ defmodule PropCheck.Test.PingPongFSM do
     log_state
   end
 
-
   # State is modelled as tuples of `{state_name, state}`
   defstruct players: [], scores: %{}
 

--- a/test/pingpong_fsm_test.exs
+++ b/test/pingpong_fsm_test.exs
@@ -60,7 +60,7 @@ defmodule PropCheck.Test.PingPongFSM do
   @max_players 100
   @players 1..@max_players |> Enum.map(&("player_#{&1}") |> String.to_atom)
 
-  def initial_state(), do: :empty_state
+  def initial_state, do: :empty_state
   def initial_state_data, do: %__MODULE__{}
 
   def empty_state(_) do
@@ -135,7 +135,7 @@ defmodule PropCheck.Test.PingPongFSM do
   def next_state_data(_from, _target, state, _res, _call), do: state
 
   # ensure all player processes are dead
-  defp kill_all_player_processes() do
+  defp kill_all_player_processes do
     Process.registered
     |> Enum.filter(&(Atom.to_string(&1) |> String.starts_with?("player_")))
     |> Enum.each(fn name ->

--- a/test/pingpong_fsm_test.exs
+++ b/test/pingpong_fsm_test.exs
@@ -104,13 +104,13 @@ defmodule PropCheck.Test.PingPongFSM do
 
   # state data is updates for adding, removing, playing.
   def next_state_data(_from, :player_state, state, _res, {:call, _m, :add_player, [p]}) do
-    if not Enum.member?(state.players, p) do
+    if Enum.member?(state.players, p) do
+      state
+    else
       %__MODULE__{state |
           players: [p | state.players],
           scores: Map.put_new(state.scores, p, 0)
         }
-    else
-      state
     end
   end
   def next_state_data(:player_state, _target, state, _res, {:call, _, :remove_player, [p]}) do

--- a/test/pingpong_fsm_test.exs
+++ b/test/pingpong_fsm_test.exs
@@ -126,7 +126,7 @@ defmodule PropCheck.Test.PingPongFSM do
   def next_state_data(:player_state, _target, state, _res, {:call, _, :play_ping_pong, [p]}) do
     if Enum.member?(state.players, p) do
       %__MODULE__{state |
-          scores: Map.update!(state.scores, p, fn v -> v+1 end)}
+          scores: Map.update!(state.scores, p, fn v -> v + 1 end)}
     else
       state
     end

--- a/test/pingpong_statem_test.exs
+++ b/test/pingpong_statem_test.exs
@@ -34,7 +34,7 @@ defmodule PropCheck.Test.PingPongStateM do
   end
 
   # ensure all player processes are dead
-  defp kill_all_player_processes() do
+  defp kill_all_player_processes do
     Process.registered
     |> Enum.filter(&(Atom.to_string(&1)
     |> String.starts_with?("player_")))
@@ -76,7 +76,7 @@ defmodule PropCheck.Test.PingPongStateM do
     |> Enum.map(&("player_#{&1}")
     |> String.to_atom)
 
-  def name(), do: elements @players
+  def name, do: elements @players
   def name(%__MODULE__{players: player_list}), do: elements player_list
 
   def command(%__MODULE__{players: []}), do:
@@ -100,7 +100,7 @@ defmodule PropCheck.Test.PingPongStateM do
 
 
   @doc "initial model state of the state machine"
-  def initial_state(), do: %__MODULE__{}
+  def initial_state, do: %__MODULE__{}
 
   @doc """
   Update the model state after a successful call. The `state` parameter has

--- a/test/pingpong_statem_test.exs
+++ b/test/pingpong_statem_test.exs
@@ -86,9 +86,9 @@ defmodule PropCheck.Test.PingPongStateM do
       {:call, PingPongMaster, :add_player, [name()]},
       {:call, PingPongMaster, :remove_player, [name(state)]},
       {:call, PingPongMaster, :get_score, [name(state)]},
-      {:call, PingPongMaster, :play_ping_pong,[name(state)]},
-      {:call, PingPongMaster, :play_tennis,[name(state)]},
-      {:call, PingPongMaster, :play_football,[name(state)]}
+      {:call, PingPongMaster, :play_ping_pong, [name(state)]},
+      {:call, PingPongMaster, :play_tennis, [name(state)]},
+      {:call, PingPongMaster, :play_football, [name(state)]}
       ])
   end
 

--- a/test/pingpong_statem_test.exs
+++ b/test/pingpong_statem_test.exs
@@ -98,7 +98,6 @@ defmodule PropCheck.Test.PingPongStateM do
   ##
   #####################################################
 
-
   @doc "initial model state of the state machine"
   def initial_state, do: %__MODULE__{}
 

--- a/test/pingpong_test.exs
+++ b/test/pingpong_test.exs
@@ -5,6 +5,7 @@ defmodule PropCheck.Test.PingPongTest do
 
   @moduletag capture_log: true
 
+  alias PropCheck.Test.PingPongMaster
 
   # ensure all player processes are dead
   defp kill_all_player_processes() do
@@ -31,13 +32,13 @@ defmodule PropCheck.Test.PingPongTest do
 
 
   test "Strange Call Sequence" do
-    PropCheck.Test.PingPongMaster.start_link
-    PropCheck.Test.PingPongMaster.add_player :player_73
-    PropCheck.Test.PingPongMaster.play_ping_pong :player_73
-    PropCheck.Test.PingPongMaster.play_ping_pong :player_73
+    PingPongMaster.start_link
+    PingPongMaster.add_player :player_73
+    PingPongMaster.play_ping_pong :player_73
+    PingPongMaster.play_ping_pong :player_73
     :timer.sleep(50)
-    score = PropCheck.Test.PingPongMaster.get_score :player_73
-    PropCheck.Test.PingPongMaster.stop
+    score = PingPongMaster.get_score :player_73
+    PingPongMaster.stop
     kill_all_player_processes()
 
     assert score <= 2

--- a/test/pingpong_test.exs
+++ b/test/pingpong_test.exs
@@ -30,7 +30,6 @@ defmodule PropCheck.Test.PingPongTest do
     end)
   end
 
-
   test "Strange Call Sequence" do
     PingPongMaster.start_link
     PingPongMaster.add_player :player_73

--- a/test/pingpong_test.exs
+++ b/test/pingpong_test.exs
@@ -8,7 +8,7 @@ defmodule PropCheck.Test.PingPongTest do
   alias PropCheck.Test.PingPongMaster
 
   # ensure all player processes are dead
-  defp kill_all_player_processes() do
+  defp kill_all_player_processes do
     require Logger
     Process.registered
     |> Enum.filter(&(Atom.to_string(&1) |> String.starts_with?("player_")))

--- a/test/propcheck_test.exs
+++ b/test/propcheck_test.exs
@@ -12,7 +12,6 @@ defmodule PropcheckTest do
   @type my_stack(t) :: [t]
   @type tagged_stack(t) :: {:stack, [t]}
 
-
   test "find types in proper_gen.erl" do
     types = Kernel.Typespec.beam_types(:proper_gen)
     refute nil == types

--- a/test/propcheck_test.exs
+++ b/test/propcheck_test.exs
@@ -100,7 +100,7 @@ defmodule PropcheckTest do
 
         for {:attribute, _, kind, {name, _, args}} = type <- abstract_code, kind
              in [:opaque, :type, :export_type] do
-          if (name == type_name and arg_count == length(args)) do
+          if name == type_name and arg_count == length(args) do
             type
           else
             nil

--- a/test/support/counter.ex
+++ b/test/support/counter.ex
@@ -13,7 +13,7 @@ defmodule PropCheck.Test.Counter do
   @spec start_link() :: {:ok, pid}
   @spec start_link(atom) :: {:ok, pid}
   @spec start_link(reset_t, atom) :: {:ok, pid}
-  def start_link(reset \\:infinity, name \\ __MODULE__) when is_atom(name) and
+  def start_link(reset \\ :infinity, name \\ __MODULE__) when is_atom(name) and
     (reset == :infinity or is_integer(reset))
   do
     Agent.start_link(fn -> {-1, reset} end, name: name)

--- a/test/support/level.ex
+++ b/test/support/level.ex
@@ -51,7 +51,6 @@ defmodule PropCheck.Test.Level do
      "#                                                                    #",
      "######################################################################"]
 
-
   @spec level2() :: level_data()
   def level2, do:
     ["######################################################################",
@@ -138,6 +137,5 @@ defmodule PropCheck.Test.Level do
             end
       end)
     end
-
 
 end

--- a/test/support/level.ex
+++ b/test/support/level.ex
@@ -19,13 +19,13 @@ defmodule PropCheck.Test.Level do
   #######################################################################
 
   @spec level0() :: level_data()
-  def level0(), do:
+  def level0, do:
     ["#########",
      "#X     E#",
      "#########"]
 
   @spec level1() :: level_data()
-  def level1(), do:
+  def level1, do:
     ["######################################################################",
      "#                                                                    #",
      "#   E                                                                #",
@@ -53,7 +53,7 @@ defmodule PropCheck.Test.Level do
 
 
   @spec level2() :: level_data()
-  def level2(), do:
+  def level2, do:
     ["######################################################################",
      "#                                                                    #",
      "#    X                                                               #",

--- a/test/support/level.ex
+++ b/test/support/level.ex
@@ -92,19 +92,19 @@ defmodule PropCheck.Test.Level do
       build_level_line(t, acc, x, y + 1)
     defp build_level_line("#" <> t, acc, x, y) do
       m = Map.put(acc, {x, y}, :wall)
-      build_level_line(t, m, x, y+1)
+      build_level_line(t, m, x, y + 1)
     end
     defp build_level_line("X" <> t, acc, x, y) do
       m = acc
       |> Map.put({x, y}, :exit)
       |> Map.put(:exit, {x, y})
-      build_level_line(t, m, x, y+1)
+      build_level_line(t, m, x, y + 1)
     end
     defp build_level_line("E" <> t, acc, x, y) do
       m = acc
       |> Map.put({x, y}, :entrance)
       |> Map.put(:entrance, {x, y})
-      build_level_line(t, m, x, y+1)
+      build_level_line(t, m, x, y + 1)
     end
 
     #######################################################################

--- a/test/support/movie_server.ex
+++ b/test/support/movie_server.ex
@@ -1,4 +1,5 @@
 defmodule PropCheck.Test.MovieServer do
+  @moduledoc false
 
   use GenServer
 

--- a/test/support/movie_server.ex
+++ b/test/support/movie_server.ex
@@ -61,11 +61,11 @@ defmodule PropCheck.Test.MovieServer do
 
   def handle_call(:popcorn, _from, s), do: {:reply, :bon_appetit, s}
   def handle_call(:stop, _from, s), do: {:stop, :normal, :stopped, s}
-  def handle_call({:new_account, name}, _from, %__MODULE__{next_pass: p, users: u} = s) do
+  def handle_call({:new_account, name}, _from, s = %__MODULE__{next_pass: p, users: u}) do
     :ets.insert(u, {p, name, []})
     {:reply, p, %__MODULE__{s | next_pass: p + 1}}
   end
-  def handle_call({:delete_account, p}, _from, %__MODULE__{users: u} = s) do
+  def handle_call({:delete_account, p}, _from, s = %__MODULE__{users: u}) do
     reply = case :ets.lookup(u, p) do
       []          -> :not_a_client
       [{_, _, []}]  -> :ets.delete(u, p)
@@ -74,7 +74,7 @@ defmodule PropCheck.Test.MovieServer do
     end
     {:reply, reply, s}
   end
-  def handle_call({:rent, pass, movie}, _from, %__MODULE__{users: u, movies: m} = s) do
+  def handle_call({:rent, pass, movie}, _from, s = %__MODULE__{users: u, movies: m}) do
     reply = case :ets.lookup(u, pass) do
       []             -> :not_a_client
       [{_, _, rented}] -> case :ets.lookup(m, movie)  do
@@ -89,7 +89,7 @@ defmodule PropCheck.Test.MovieServer do
     end
     {:reply, reply, s}
   end
-  def handle_call({:return, pass, movie}, _from, %__MODULE__{users: u, movies: m} = s) do
+  def handle_call({:return, pass, movie}, _from, s = %__MODULE__{users: u, movies: m}) do
     reply = case :ets.lookup(u, pass) do
       []             -> :not_a_client
       [{_, _, rented}] -> case :ets.lookup(m, movie) do

--- a/test/support/movie_server.ex
+++ b/test/support/movie_server.ex
@@ -13,10 +13,10 @@ defmodule PropCheck.Test.MovieServer do
     movies: nil,
     next_pass: 0
 
-  def start_link(), do:
+  def start_link, do:
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
 
-  def stop() do
+  def stop do
     ref = Process.monitor(__MODULE__)
     GenServer.call(__MODULE__, :stop)
     receive do
@@ -39,9 +39,9 @@ defmodule PropCheck.Test.MovieServer do
     GenServer.call(__MODULE__, {:return, password, movie})
 
   @spec ask_for_popcorn() :: :bon_appetit
-  def ask_for_popcorn(), do: GenServer.call(__MODULE__, :popcorn)
+  def ask_for_popcorn, do: GenServer.call(__MODULE__, :popcorn)
 
-  def available_movies(), do: @movies
+  def available_movies, do: @movies
 
   ##########################################################
 

--- a/test/support/movie_server.ex
+++ b/test/support/movie_server.ex
@@ -2,8 +2,8 @@ defmodule PropCheck.Test.MovieServer do
 
   use GenServer
 
-  @movies [{:mary_poppins,3}, {:finding_nemo,2}, {:despicable_me,3},
-      {:toy_story,5}, {:the_lion_king,2}, {:peter_pan,1}]
+  @movies [{:mary_poppins, 3}, {:finding_nemo, 2}, {:despicable_me, 3},
+      {:toy_story, 5}, {:the_lion_king, 2}, {:peter_pan, 1}]
 
   @type name :: atom
   @type movie :: atom
@@ -67,7 +67,7 @@ defmodule PropCheck.Test.MovieServer do
   def handle_call({:delete_account, p}, _from, %__MODULE__{users: u} = s) do
     reply = case :ets.lookup(u, p) do
       []          -> :not_a_client
-      [{_,_,[]}]  -> :ets.delete(u, p)
+      [{_, _, []}]  -> :ets.delete(u, p)
                      :account_deleted
       [{_, _, _}] -> :return_movies_first
     end
@@ -76,7 +76,7 @@ defmodule PropCheck.Test.MovieServer do
   def handle_call({:rent, pass, movie}, _from, %__MODULE__{users: u, movies: m}=s) do
     reply = case :ets.lookup(u, pass) do
       []             -> :not_a_client
-      [{_,_,rented}] -> case :ets.lookup(m, movie)  do
+      [{_, _, rented}] -> case :ets.lookup(m, movie)  do
         [] -> rented
         [{_, 0}] -> rented
         [{_, n}] ->
@@ -91,11 +91,11 @@ defmodule PropCheck.Test.MovieServer do
   def handle_call({:return, pass, movie}, _from, %__MODULE__{users: u, movies: m}=s) do
     reply = case :ets.lookup(u, pass) do
       []             -> :not_a_client
-      [{_,_,rented}] -> case :ets.lookup(m, movie) do
+      [{_, _, rented}] -> case :ets.lookup(m, movie) do
         [] -> rented
         [{_, n}] ->
           new_rented = rented |> List.delete(movie)
-          :ets.update_element(u, pass, {3,new_rented})
+          :ets.update_element(u, pass, {3, new_rented})
           :ets.update_element(m, movie, {2, n+1})
           new_rented
       end

--- a/test/support/movie_server.ex
+++ b/test/support/movie_server.ex
@@ -63,7 +63,7 @@ defmodule PropCheck.Test.MovieServer do
   def handle_call(:stop, _from, s), do: {:stop, :normal, :stopped, s}
   def handle_call({:new_account, name}, _from, %__MODULE__{next_pass: p, users: u} = s) do
     :ets.insert(u, {p, name, []})
-    {:reply, p, %__MODULE__{s | next_pass: p+1}}
+    {:reply, p, %__MODULE__{s | next_pass: p + 1}}
   end
   def handle_call({:delete_account, p}, _from, %__MODULE__{users: u} = s) do
     reply = case :ets.lookup(u, p) do
@@ -74,7 +74,7 @@ defmodule PropCheck.Test.MovieServer do
     end
     {:reply, reply, s}
   end
-  def handle_call({:rent, pass, movie}, _from, %__MODULE__{users: u, movies: m}=s) do
+  def handle_call({:rent, pass, movie}, _from, %__MODULE__{users: u, movies: m} = s) do
     reply = case :ets.lookup(u, pass) do
       []             -> :not_a_client
       [{_, _, rented}] -> case :ets.lookup(m, movie)  do
@@ -83,13 +83,13 @@ defmodule PropCheck.Test.MovieServer do
         [{_, n}] ->
           new_rented = [movie | rented]
           :ets.update_element(u, pass, {3, new_rented})
-          :ets.update_element(m, movie, {2, n-1})
+          :ets.update_element(m, movie, {2, n - 1})
           new_rented
       end
     end
     {:reply, reply, s}
   end
-  def handle_call({:return, pass, movie}, _from, %__MODULE__{users: u, movies: m}=s) do
+  def handle_call({:return, pass, movie}, _from, %__MODULE__{users: u, movies: m} = s) do
     reply = case :ets.lookup(u, pass) do
       []             -> :not_a_client
       [{_, _, rented}] -> case :ets.lookup(m, movie) do
@@ -97,7 +97,7 @@ defmodule PropCheck.Test.MovieServer do
         [{_, n}] ->
           new_rented = rented |> List.delete(movie)
           :ets.update_element(u, pass, {3, new_rented})
-          :ets.update_element(m, movie, {2, n+1})
+          :ets.update_element(m, movie, {2, n + 1})
           new_rented
       end
     end

--- a/test/support/pingpong_master.ex
+++ b/test/support/pingpong_master.ex
@@ -21,11 +21,11 @@ defmodule PropCheck.Test.PingPongMaster do
   # Master's API
   # -------------------------------------------------------------------
 
-  def start_link() do
+  def start_link do
     GenServer.start_link(__MODULE__, [], [name: __MODULE__])
   end
 
-  def stop() do
+  def stop do
     GenServer.stop(__MODULE__, :normal)
   end
 

--- a/test/support/pingpong_master.ex
+++ b/test/support/pingpong_master.ex
@@ -111,12 +111,10 @@ defmodule PropCheck.Test.PingPongMaster do
   end
 
   defp robust_send(name, msg) do
-    try do
-      send(name, msg)
-      :ok
-    catch
-      :error, :badarg -> {:dead_player, name}
-    end
+    send(name, msg)
+    :ok
+  catch
+    :error, :badarg -> {:dead_player, name}
   end
 
   # -------------------------------------------------------------------

--- a/test/support/pingpong_master.ex
+++ b/test/support/pingpong_master.ex
@@ -150,7 +150,7 @@ defmodule PropCheck.Test.PingPongMaster do
   end
   def handle_call({:ping, from_name}, _from, scores) do
     # Logger.debug "Master: Ping Pong Game for #{inspect from_name}"
-    if (scores |> Map.has_key?(from_name)) do
+    if scores |> Map.has_key?(from_name) do
       {:reply, :pong, scores |> Map.update!(from_name, &(&1 + 1))}
     else
       {:reply, {:removed, from_name}, scores}

--- a/test/support/sequential_cache.ex
+++ b/test/support/sequential_cache.ex
@@ -45,7 +45,7 @@ defmodule PropCheck.Test.Cache do
     # Logger.debug "Current: #{current}, Max: #{inspect max}"
     if current < max do
       # Logger.debug "Cache: Incrementally add at pos #{current + 1}"
-      :ets.insert(@cache_name, [{current+1, {key, val}},
+      :ets.insert(@cache_name, [{current + 1, {key, val}},
                          {:count, current + 1, max}])
     else
       # table is full, override from the beginning

--- a/test/support/sequential_cache.ex
+++ b/test/support/sequential_cache.ex
@@ -13,7 +13,7 @@ defmodule PropCheck.Test.Cache do
     GenServer.start_link(__MODULE__, [n], name: @cache_name)
   end
 
-  def stop(), do: GenServer.stop(__MODULE__)
+  def stop, do: GenServer.stop(__MODULE__)
 
   @doc """
   Finding keys is done through scanning an ETS table with `:ets.match/2`
@@ -57,13 +57,13 @@ defmodule PropCheck.Test.Cache do
   @doc """
   The cache gets flushed by removing all the entries and resetting its counters
   """
-  def flush() do
+  def flush do
     [{:count, _, max}] = :ets.lookup(@cache_name, :count)
     :ets.delete_all_objects(@cache_name)
     :ets.insert(@cache_name, {:count, 0, max})
   end
 
-  def dump() do
+  def dump do
     :ets.tab2list(@cache_name)
     |> Enum.sort_by(fn
       {index, {_k, _v}} -> index

--- a/test/support/stack.ex
+++ b/test/support/stack.ex
@@ -1,6 +1,5 @@
 defmodule PropCheck.Test.Stack do
 
-
   @opaque stack(t) :: [t] # when t: var
   @opaque stack :: stack(any)
 

--- a/test/support/stack.ex
+++ b/test/support/stack.ex
@@ -1,4 +1,5 @@
 defmodule PropCheck.Test.Stack do
+  @moduledoc false
 
   @opaque stack(t) :: [t] # when t: var
   @opaque stack :: stack(any)

--- a/test/support/tree.ex
+++ b/test/support/tree.ex
@@ -30,7 +30,7 @@ defmodule PropCheck.Test.Tree do
   @doc "Corrected delete implementation"
   @spec delete2(tree(t), t) :: tree(t) when t: var
   def delete2(:leaf, _), do: :leaf
-  def delete2({:node, x, l, r}, x), do: join(delete2(l, x), delete2(r,x))
+  def delete2({:node, x, l, r}, x), do: join(delete2(l, x), delete2(r, x))
   def delete2({:node, y, l, r}, x), do: {:node, y, delete2(l, x), delete2(r, x)}
 
   @spec tree_sum(tree(number)) :: number

--- a/test/targeted_path_test.exs
+++ b/test/targeted_path_test.exs
@@ -15,7 +15,6 @@ defmodule PropCheck.Test.TargetPathTest do
   def move(:up, {x, y}),    do: {x, y+1}
   def move(:down, {x, y}),  do: {x, y-1}
 
-
   property "trivial path", [:verbose, numtests: 10] do
     forall p <- path() do
       {x,y} = Enum.reduce(p, {0, 0}, &move/2)

--- a/test/targeted_path_test.exs
+++ b/test/targeted_path_test.exs
@@ -10,10 +10,10 @@ defmodule PropCheck.Test.TargetPathTest do
 
   def path, do: list(oneof([:left, :right, :up, :down]))
 
-  def move(:left, {x, y}),  do: {x-1, y}
-  def move(:right, {x, y}), do: {x+1, y}
-  def move(:up, {x, y}),    do: {x, y+1}
-  def move(:down, {x, y}),  do: {x, y-1}
+  def move(:left, {x, y}),  do: {x - 1, y}
+  def move(:right, {x, y}), do: {x + 1, y}
+  def move(:up, {x, y}),    do: {x, y + 1}
+  def move(:down, {x, y}),  do: {x, y - 1}
 
   property "trivial path", [:verbose, numtests: 10] do
     forall p <- path() do
@@ -28,7 +28,7 @@ defmodule PropCheck.Test.TargetPathTest do
     forall_targeted p <- path() do
       {x, y} = Enum.reduce(p, {0, 0}, &move/2)
       IO.write "(#{x},#{y})."
-      maximize(x-y)
+      maximize(x - y)
       true
     end
     )
@@ -44,7 +44,7 @@ defmodule PropCheck.Test.TargetPathTest do
     forall_targeted p <- path() do
       {x, y} = Enum.reduce(p, {0, 0}, &move/2)
       IO.write "(#{x},#{y})."
-      distance_square = (x*x + y*y)
+      distance_square = (x * x + y * y)
       maximize(distance_square)
       distance_square < 100
     end
@@ -59,7 +59,7 @@ defmodule PropCheck.Test.TargetPathTest do
     exists p <- path() do
       {x, y} = Enum.reduce(p, {0, 0}, &move/2)
       IO.write "(#{x},#{y})."
-      distance_square = (x*x + y*y)
+      distance_square = (x * x + y * y)
       maximize(distance_square)
       distance_square >= 100
     end

--- a/test/targeted_path_test.exs
+++ b/test/targeted_path_test.exs
@@ -17,7 +17,7 @@ defmodule PropCheck.Test.TargetPathTest do
 
   property "trivial path", [:verbose, numtests: 10] do
     forall p <- path() do
-      {x,y} = Enum.reduce(p, {0, 0}, &move/2)
+      {x, y} = Enum.reduce(p, {0, 0}, &move/2)
       IO.write "(#{x},#{y})."
       true
     end
@@ -26,7 +26,7 @@ defmodule PropCheck.Test.TargetPathTest do
   property "simple targeted path", [:verbose, search_steps: 100] do
     numtests(10,
     forall_targeted p <- path() do
-      {x,y} = Enum.reduce(p, {0, 0}, &move/2)
+      {x, y} = Enum.reduce(p, {0, 0}, &move/2)
       IO.write "(#{x},#{y})."
       maximize(x-y)
       true
@@ -42,7 +42,7 @@ defmodule PropCheck.Test.TargetPathTest do
   """
   property "reach a path of distance sqrt(100)", [:verbose, search_steps: 100] do
     forall_targeted p <- path() do
-      {x,y} = Enum.reduce(p, {0, 0}, &move/2)
+      {x, y} = Enum.reduce(p, {0, 0}, &move/2)
       IO.write "(#{x},#{y})."
       distance_square = (x*x + y*y)
       maximize(distance_square)
@@ -57,7 +57,7 @@ defmodule PropCheck.Test.TargetPathTest do
   """
   property "exists: at least one path with distance >= sqrt(100) exists", [:verbose, search_steps: 100] do
     exists p <- path() do
-      {x,y} = Enum.reduce(p, {0, 0}, &move/2)
+      {x, y} = Enum.reduce(p, {0, 0}, &move/2)
       IO.write "(#{x},#{y})."
       distance_square = (x*x + y*y)
       maximize(distance_square)

--- a/test/targeted_path_test.exs
+++ b/test/targeted_path_test.exs
@@ -8,7 +8,7 @@ defmodule PropCheck.Test.TargetPathTest do
 
   require Logger
 
-  def path(), do: list(oneof([:left, :right, :up, :down]))
+  def path, do: list(oneof([:left, :right, :up, :down]))
 
   def move(:left, {x, y}),  do: {x-1, y}
   def move(:right, {x, y}), do: {x+1, y}

--- a/test/targeted_tree_test.exs
+++ b/test/targeted_tree_test.exs
@@ -45,7 +45,7 @@ defmodule PropCheck.Test.TargetTreeTest do
       {left, right} = weight
       IO.write(" #{inspect weight}")
       # ensure that the left tree is larger than the right one
-      maximize(left-right)
+      maximize(left - right)
       true # this property holds always
     end
   end
@@ -77,7 +77,7 @@ defmodule PropCheck.Test.TargetTreeTest do
       {left, right} = weight
       IO.write(" #{inspect weight}")
       # ensure that the left tree is larger than the right one
-      maximize(left-right)
+      maximize(left - right)
       true # this property holds always
     end
   end
@@ -97,7 +97,7 @@ defmodule PropCheck.Test.TargetTreeTest do
         {left, right} = weight
         IO.write(" #{inspect weight}")
         # ensure that the left tree is larger than the right one
-        maximize(left-right)
+        maximize(left - right)
         false # guarantees a full search for exists
       end
     end

--- a/test/targeted_tree_test.exs
+++ b/test/targeted_tree_test.exs
@@ -9,7 +9,7 @@ defmodule PropCheck.Test.TargetTreeTest do
   require Logger
 
   @doc "Make a tree from a list"
-  def to_tree(l), do: Enum.reduce(l,:undefined, &insert/2)
+  def to_tree(l), do: Enum.reduce(l, :undefined, &insert/2)
 
   @doc "Insert into a tree, the empty tree is `:undefined`"
   def insert(n, node = {:node, m, _l, _r}) when n == m, do: node
@@ -26,7 +26,7 @@ defmodule PropCheck.Test.TargetTreeTest do
     {rl, rr} = sides(right)
     {count_inner(left) + ll + lr, count_inner(right) + rl + rr}
   end
-  def sides(_), do: {0,0}
+  def sides(_), do: {0, 0}
   def count_inner({:node, _, _, _}), do: 1
   def count_inner(_), do: 0
 

--- a/test/targeted_tree_test.exs
+++ b/test/targeted_tree_test.exs
@@ -91,7 +91,7 @@ defmodule PropCheck.Test.TargetTreeTest do
       not_exists t <- user_nf(
           # trick: wrap the list value l into the let to construct the
           # required generator for user_nf
-          ( let x <- l, do: to_tree(x) ),
+          (let x <- l, do: to_tree(x)),
           next_tree()) do
         weight = sides(t)
         {left, right} = weight

--- a/test/targeted_tree_test.exs
+++ b/test/targeted_tree_test.exs
@@ -33,7 +33,7 @@ defmodule PropCheck.Test.TargetTreeTest do
   #####################################################################################
 
   ## Generator for trees
-  def tree() do
+  def tree do
     let l <- non_empty(list(integer())) do
       to_tree(l)
     end
@@ -62,7 +62,7 @@ defmodule PropCheck.Test.TargetTreeTest do
   # define our own neighborhood function achieve even more left-heavy trees
 
   @doc "Returns the generator function for next value depending on the temperature"
-  def next_tree() do
+  def next_tree do
     fn old_tree, {_, temperature} ->
       let n <- integer() do
         scaled_value = trunc(n * temperature * 100)

--- a/test/tree_test.exs
+++ b/test/tree_test.exs
@@ -91,10 +91,10 @@ defmodule PropCheck.TreeTest do
   def tree5(g), do: sized(s, tree5(s, g))
   def tree5(0, _), do: :leaf
   def tree5(s, g), do:
-    frequency [
+    frequency([
       {1, tree5(0, g)},
       {9, lazy {:node, g, tree5(div(s, 2), g), tree5(div(s, 2), g)}}
-    ]
+    ])
 
   @doc """
   Finally, we set up a more efficient shrinking strategy: pick each of the


### PR DESCRIPTION
This pull requests adds [credo](https://github.com/rrrene/credo) to lint `PropCheck`. This lint is also done by CI.

See [here](https://circleci.com/gh/evnu/propcheck/58) for the initial list of things Credo complains about when using `mix credo --strict`. I added a configuration with `mix credo gen.config`.

Fix #98.