### PR TITLE
ci: Store core and crash dumps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
           keys:
             - testing-elixir-v<< parameters.version >>
       - run: MIX_ENV=test mix do deps.get, compile
+      - run: ulimit -c unlimited
       - run: mix test --cover --trace --exclude will_fail:true --exclude unstable_test:true
       - store_test_results:
           path: _build/test/lib/propcheck
@@ -26,6 +27,16 @@ jobs:
             - _build
             - deps
             - ~/.mix
+      - run:
+          command: |
+            mkdir -p /tmp/{erl_crash,core_dumps}
+            cp erl_crash* /tmp/erl_crash
+            cp core.* /tmp/core_dumps
+          when: on_fail
+      - store_artifacts:
+          path: /tmp/erl_crash
+      - store_artifacts:
+          path: /tmp/core_dumps
   lint:
     parameters:
       version:


### PR DESCRIPTION
Part of #101. Enable storing crash and core dumps in CircleCI. See [the documentation](https://circleci.com/docs/2.0/artifacts/#uploading-core-files) on how to retrieve such artifacts, if any core or crash dumps were written.