### PR TITLE
Replace CircleCI badge with shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 `PropCheck` is a testing library, that provides a wrapper around PropEr, an Erlang
 based property testing framework in the spirit of QuickCheck.
 
-[![CircleCI](https://circleci.com/gh/alfert/propcheck.svg?style=svg)](https://circleci.com/gh/alfert/propcheck)
+[![CircleCI](https://img.shields.io/circleci/project/github/alfert/propcheck/master.svg)](https://circleci.com/gh/alfert/propcheck)
 [![Hex.pm version](https://img.shields.io/hexpm/v/propcheck.svg)](https://hex.pm/packages/propcheck)
 
 ## Installation


### PR DESCRIPTION
A small stylistic change for the README. The CircleCI badge looks out-of-place on the left of the badge for hex.pm, as the style is different.

Before:

[![CircleCI](https://circleci.com/gh/alfert/propcheck.svg?style=svg)](https://circleci.com/gh/alfert/propcheck)

After:

[![CircleCI](https://img.shields.io/circleci/project/github/alfert/propcheck/master.svg)](https://circleci.com/gh/alfert/propcheck)

Rendered:

![image](https://user-images.githubusercontent.com/224554/55499383-29c53400-5646-11e9-85fa-fc616bdb2c93.png)
