### PR TITLE
Configure storing counter examples with tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,10 @@ jobs:
       - run: MIX_ENV=test mix do deps.get, compile
       - run: ulimit -c unlimited
       - run: mix test --cover --trace --exclude will_fail:true --exclude unstable_test:true
+      - run:
+          command: |
+            mix test test/store_counter_examples_test.exs --include will_fail:true && exit 1
+            mix test test/verify_counter_examples_test.exs
       - store_test_results:
           path: _build/test/lib/propcheck
       - save_cache:

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -179,7 +179,7 @@ defmodule PropCheck.Properties do
             CounterStrike.add_counter_example(name, counter_example)
             "Counter example stored."
           else
-            "Counter example NOT stored, :store_counter_example is set."
+            "Counter example NOT stored, :store_counter_example is set to false."
           end
 
         raise ExUnit.AssertionError, [

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -39,6 +39,47 @@ defmodule PropCheck.Properties do
   After a property was ran successfully against a previous counter example, PropCheck will
   run the property again to check if other counter examples can be found.
 
+  ### Disable Storing Counter Examples
+
+  Storing counter examples can be disabled using the `:store_counter_example` tag. This
+  can be done in three different scopes: module-wide scope, describe-wide scope or for
+  a single property.
+
+  **NOTE** that this facility is meant for properties which cannot run with a value generated
+  in a previous test run. This should usually not be the case, and `:store_counter_example`
+  should only be used after careful consideration.
+
+  Disable for all properties in a module:
+
+  ```
+  defmodule Test do
+    # ...
+    @moduletag store_counter_example: false
+    #...
+  end
+  ```
+
+  Disable for all properties in a describe block:
+
+  ```
+  defmodule Test do
+    # ...
+    describe "describe block" do
+      @describetag store_counter_example: false
+      # ...
+    end
+  end
+  ```
+
+  Disable for a single property:
+
+  ```
+  @tag store_counter_example: false
+  property "a property" do
+    # ...
+  end
+  ```
+
   """
   defmacro property(name, opts \\ [:quiet], var \\ quote(do: _), do: p_block) do
       block = quote do
@@ -49,13 +90,25 @@ defmodule PropCheck.Properties do
       quote bind_quoted: [name: name, block: block, var: var, opts: opts] do
           ExUnit.plural_rule("property", "properties")
           %{module: module} = __ENV__
+
+          moduletag = Module.get_attribute(module, :moduletag) |> List.flatten()
+          describetag = Module.get_attribute(module, :describetag) |> List.flatten()
+          tag = Module.get_attribute(module, :tag) |> List.flatten()
+
+          # intended precedence: tag > describetag > moduletag
+          store_counter_example =
+            moduletag
+            |> Keyword.merge(describetag)
+            |> Keyword.merge(tag)
+            |> Keyword.get(:store_counter_example, true)
+
           # @tag failing_prop: tag_property({module, prop_name, []})
           tags = [[failing_prop: tag_property({module, name, []})]]
           prop_name = ExUnit.Case.register_test(__ENV__, :property, name, tags)
           def unquote(prop_name)(unquote(var)) do
             p = unquote(block)
             mfa = {unquote(module), unquote(prop_name), []}
-            execute_property(p, mfa, unquote(opts))
+            execute_property(p, mfa, unquote(opts), unquote(store_counter_example))
             :ok
           end
       end
@@ -79,7 +132,7 @@ defmodule PropCheck.Properties do
   @doc false
   # Executes the body `p` of property `name` with PropEr options `opts`
   # by ExUnit.
-  def execute_property(p, name, opts) do
+  def execute_property(p, name, opts, store_counter_example?) do
     should_fail = is_tuple(p) and elem(p, 0) == :fails
     # Logger.debug "Execute property #{inspect name} "
     case CounterStrike.counter_example(name) do
@@ -98,14 +151,14 @@ defmodule PropCheck.Properties do
           e = {:error, _} -> e
         end
     end
-    |> handle_check_results(name, should_fail)
+    |> handle_check_results(name, should_fail, store_counter_example?)
   end
 
   defp qc(p, opts), do: PropCheck.quickcheck(p, [:long_result] ++ opts)
 
   # Handles the result of executing quick check or a re-check of a counter example.
   # In this method a new found counter example is added to `CounterStrike`.
-  defp handle_check_results(results, name, should_fail) do
+  defp handle_check_results(results, name, should_fail, store_counter_example?) do
     case results do
       error = {:error, _} ->
         raise ExUnit.AssertionError, [
@@ -121,13 +174,22 @@ defmodule PropCheck.Properties do
           expr: nil]
       counter_example when is_list(counter_example) and should_fail -> true
       counter_example when is_list(counter_example) ->
-        CounterStrike.add_counter_example(name, counter_example)
+        counter_example_message =
+          if store_counter_example? do
+            CounterStrike.add_counter_example(name, counter_example)
+            "Counter example stored."
+          else
+            "Counter example NOT stored, :store_counter_example is set."
+          end
+
         raise ExUnit.AssertionError, [
           message: """
           Property #{mfa_to_string name} failed. Counter-Example is:
           #{inspect counter_example, pretty: true}
+
+          #{counter_example_message}
           """,
-              expr: nil]
+          expr: nil]
       {:rerun_failed, counter_example} when is_list(counter_example) ->
         CounterStrike.add_counter_example(name, counter_example)
         raise ExUnit.AssertionError, [

--- a/lib/statem_dsl.ex
+++ b/lib/statem_dsl.ex
@@ -157,12 +157,11 @@ defmodule PropCheck.StateM.DSL do
         end
       end
 
-
   ## Increasing the Number of Commands in a Sequence
   Sometimes issues can hide when the command sequences are short. In order to
   tease out these hidden bugs we can increase the number of commands generated
   by using the `max_size` option in our property.
-  
+
         property "run the sequential cache", [max_size: 250] do
         forall cmds <- commands(__MODULE__) do
           Cache.start_link(@cache_size)

--- a/test/counterstrike_test.exs
+++ b/test/counterstrike_test.exs
@@ -59,7 +59,7 @@ defmodule PropCheck.Test.CounterStrikeTest do
       use ExUnit.Case
       use PropCheck
 
-      @tag :skip # will be run manually
+      @tag will_fail: true # must be run manually
       property "cant_generate" do
         # Check that no counterexample is stored if PropEr reported an error
         gen = such_that b <- false, when: b

--- a/test/store_counter_examples_test.exs
+++ b/test/store_counter_examples_test.exs
@@ -1,22 +1,12 @@
-defmodule CheckCounterExample do
-  @moduledoc false
-  alias PropCheck.CounterStrike
-
-  def check(mfa) do
-    CounterStrike.counter_example(mfa)
-  end
-end
-
+#
+# Tests to verify the behaviour of storing counter examples. These tests here
+# intentionally fail, but no counter examples should be stored. In VerifyCounterExampleTest,
+# we can verify that no test here resulted in a stored counter example.
+#
 defmodule StoreCounterExample.ModuleTag do
   use ExUnit.Case
   use PropCheck
   @moduletag store_counter_example: false
-
-  setup_all do
-    on_exit fn ->
-      assert :none == CheckCounterExample.check({__MODULE__, :"property failing", []})
-    end
-  end
 
   @tag will_fail: true
   property "failing" do
@@ -29,12 +19,6 @@ end
 defmodule StoreCounterExample.DescribeTag do
   use ExUnit.Case
   use PropCheck
-
-  setup_all do
-    on_exit fn ->
-      assert :none == CheckCounterExample.check({__MODULE__, :"property failing", []})
-    end
-  end
 
   describe "store counter example with describe" do
     @describetag store_counter_example: false
@@ -51,12 +35,6 @@ end
 defmodule StoreCounter.ExampleTag do
   use ExUnit.Case
   use PropCheck
-
-  setup_all do
-    on_exit fn ->
-      assert :none == CheckCounterExample.check({__MODULE__, :"property failing", []})
-    end
-  end
 
   @tag store_counter_example: false
   @tag will_fail: true

--- a/test/store_counter_examples_test.exs
+++ b/test/store_counter_examples_test.exs
@@ -1,0 +1,68 @@
+defmodule CheckCounterExample do
+  @moduledoc false
+  alias PropCheck.CounterStrike
+
+  def check(mfa) do
+    CounterStrike.counter_example(mfa)
+  end
+end
+
+defmodule StoreCounterExample.ModuleTag do
+  use ExUnit.Case
+  use PropCheck
+  @moduletag store_counter_example: false
+
+  setup_all do
+    on_exit fn ->
+      assert :none == CheckCounterExample.check({__MODULE__, :"property failing", []})
+    end
+  end
+
+  @tag will_fail: true
+  property "failing" do
+    forall n <- integer(0, :inf) do
+      n < 0
+    end
+  end
+end
+
+defmodule StoreCounterExample.DescribeTag do
+  use ExUnit.Case
+  use PropCheck
+
+  setup_all do
+    on_exit fn ->
+      assert :none == CheckCounterExample.check({__MODULE__, :"property failing", []})
+    end
+  end
+
+  describe "store counter example with describe" do
+    @describetag store_counter_example: false
+
+    @tag will_fail: true
+    property "failing" do
+      forall n <- integer(0, :inf) do
+        n < 0
+      end
+    end
+  end
+end
+
+defmodule StoreCounter.ExampleTag do
+  use ExUnit.Case
+  use PropCheck
+
+  setup_all do
+    on_exit fn ->
+      assert :none == CheckCounterExample.check({__MODULE__, :"property failing", []})
+    end
+  end
+
+  @tag store_counter_example: false
+  @tag will_fail: true
+  property "failing" do
+    forall n <- integer(0, :inf) do
+      n < 0
+    end
+  end
+end

--- a/test/verify_counter_examples_test.exs
+++ b/test/verify_counter_examples_test.exs
@@ -1,0 +1,18 @@
+defmodule VerifyCounterExampleTest do
+  # The tests here verify that CheckCounterExamplesTest did indeed not store
+  # any counter examples.
+  use ExUnit.Case
+
+  @modules [
+    StoreCounterExample.ModuleTag,
+    StoreCounterExample.DescribeTag,
+    StoreCounterExample.ExampleTag
+  ]
+
+  for module <- @modules do
+    test "no counter examples stored for #{module}" do
+      assert :none ==
+               PropCheck.CounterStrike.counter_example({unquote(module), ":property failing", []})
+    end
+  end
+end


### PR DESCRIPTION
This tag allows to configure that counter examples should not be stored. The tag can be used in `@moduletag`, `@describetag` and a regular `@tag`. It can also be used multiple times with the given precedence: tag > describetag > moduletag

The message of a failed property indicates if a counter example was stored or not. For example, if storing a counter example is disabled by any of the tags mentioned above, the following is appended to the error:

> Counter example NOT stored, :store_counter_example is set.

Note that testing this feature is cumbersome. I added `test/store_counter_examples_test.exs` to check that it works, but apparently there is no way to tell ExUnit to ignore some intentionally failing test cases. The tests use an `on_exit` handler registered with `setup_all` in order to ensure that the counter examples are checked after the test cases are run.

See [this](https://circleci.com/gh/evnu/propcheck/146) pipeline, were I ran the tests explicitly to check that counter examples are not stored. Example output:

```
1) property failing (StoreCounter.ExampleTag)
     test/store_counter_examples_test.exs:63
     Property Elixir.StoreCounter.ExampleTag.property failing() failed. Counter-Example is:
     [0]
     
     Counter example NOT stored, :store_counter_example is set.
     
     code: nil
     stacktrace:
       (propcheck) lib/properties.ex:185: PropCheck.Properties.handle_check_results/4
       test/store_counter_examples_test.exs:63: (test)
```

@alfert Maybe you have an idea how to test this in CI. The only option I currently see is to store the expected output as a file, and compare the output of `mix test test/store_counter_examples_test.exs` with the expected output.

Fix #105.