### PR TITLE
Adds max_size example to StateM.DSL documentation

### DIFF
--- a/lib/statem_dsl.ex
+++ b/lib/statem_dsl.ex
@@ -74,7 +74,7 @@ defmodule PropCheck.StateM.DSL do
       defcommand :find do
         def impl(key), do: Cache.find(key)
         def args(_state), do: [key()]
-        def pre(_state, [_key]}), do: true
+        def pre(_state, [_key]), do: true
       end
 
   If the precondition is satisfied, the call can happen. After the call, the SUT
@@ -89,7 +89,7 @@ defmodule PropCheck.StateM.DSL do
       defcommand :find do
         def impl(key), do: Cache.find(key)
         def args(_state), do: [key()]
-        def pre(_state, [_key]}), do: true
+        def pre(_state, [_key]), do: true
         def next(old_state, _args, call_result), do: old_state
       end
 
@@ -105,7 +105,7 @@ defmodule PropCheck.StateM.DSL do
       defcommand :find do
         def impl(key), do: Cache.find(key)
         def args(_state), do: [key()]
-        def pre(_state, [_key]}), do: true
+        def pre(_state, [_key]), do: true
         def next(old_state, _args, _call_result), do: old_state
         def post(entries, [key], call_result) do
           case List.keyfind(entries, key, 0, false) do

--- a/lib/statem_dsl.ex
+++ b/lib/statem_dsl.ex
@@ -74,7 +74,7 @@ defmodule PropCheck.StateM.DSL do
       defcommand :find do
         def impl(key), do: Cache.find(key)
         def args(_state), do: [key()]
-        def pre(_state, [_key]), do: true
+        def pre(_state, [_key]}), do: true
       end
 
   If the precondition is satisfied, the call can happen. After the call, the SUT
@@ -89,7 +89,7 @@ defmodule PropCheck.StateM.DSL do
       defcommand :find do
         def impl(key), do: Cache.find(key)
         def args(_state), do: [key()]
-        def pre(_state, [_key]), do: true
+        def pre(_state, [_key]}), do: true
         def next(old_state, _args, call_result), do: old_state
       end
 
@@ -105,7 +105,7 @@ defmodule PropCheck.StateM.DSL do
       defcommand :find do
         def impl(key), do: Cache.find(key)
         def args(_state), do: [key()]
-        def pre(_state, [_key]), do: true
+        def pre(_state, [_key]}), do: true
         def next(old_state, _args, _call_result), do: old_state
         def post(entries, [key], call_result) do
           case List.keyfind(entries, key, 0, false) do
@@ -157,6 +157,19 @@ defmodule PropCheck.StateM.DSL do
         end
       end
 
+
+  ## Increasing the Number of Commands in a Sequence
+  Sometimes issues can hide when the command sequences are short. In order to
+  tease out these hidden bugs we can increase the number of commands generated
+  by using the `max_size` option in our property.
+  
+        property "run the sequential cache", [max_size: 250] do
+        forall cmds <- commands(__MODULE__) do
+          Cache.start_link(@cache_size)
+          execution = run_commands(cmds)
+          Cache.stop()
+          (execution.result == :ok)
+        end
   """
 
   use PropCheck


### PR DESCRIPTION

I find that this is a really important aspect when using stateful property-based
Testing. I thought we should document the current path, and have a place to
put something like `more_commands` in later.

Amos King @adkron <amos@binarynoggin.com>