### PR TITLE
Propagate :verbose to forall macro

### DIFF
--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -383,6 +383,8 @@ defmodule PropCheck do
 
     defp forall_impl(var, rawtype, opts, prop) do
       quote do
+        property_opts = Process.get(:property_opts, [])
+        verbose = :verbose in property_opts || :verbose in unquote(opts)
         :proper.forall(
           unquote(rawtype),
           fn(unquote(var)) ->
@@ -391,7 +393,7 @@ defmodule PropCheck do
             rescue
               e in ExUnit.AssertionError ->
                 stacktrace = System.stacktrace
-                if :verbose in unquote(opts) do
+                if verbose do
                   e |> ExUnit.AssertionError.message() |> IO.write()
                   formatted = Exception.format_stacktrace(stacktrace)
                   IO.puts("stacktrace:\n#{formatted}")

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -106,6 +106,9 @@ defmodule PropCheck.Properties do
           tags = [[failing_prop: tag_property({module, name, []})]]
           prop_name = ExUnit.Case.register_test(__ENV__, :property, name, tags)
           def unquote(prop_name)(unquote(var)) do
+            # Store opts in process dictionary to make them available within macros such
+            # as forall
+            Process.put(:property_opts, unquote(opts))
             p = unquote(block)
             mfa = {unquote(module), unquote(prop_name), []}
             execute_property(p, mfa, unquote(opts), unquote(store_counter_example))


### PR DESCRIPTION
This is a follow-up to #48.

When using assertions, :verbose must be set to see the actual output if
an assertion fails. Alas, a user must actually used :verbose twice, once
for the forall macro, and once for a property if forall is used within
that macro. Example:

    property "failing", [:verbose] do
        forall n <- nat(), [:verbose] do
          assert n <= 0
        end
    end

This is currently necessary as we cannot share state between the two
macros. This changeset rectifies that by making the options to the
property available to the forall macro. The approach chosen here is to
use the process dictionary. This is not as functionally clean as one
might want, but it is a simple way to achieve that :verbose is only
needed once in the example above:

    property "failing", [:verbose] do
        forall n <- nat() do
          assert n <= 0
        end
    end