### PR TITLE
Add a way to set default options

### DIFF
--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -8,10 +8,13 @@ defmodule PropCheck do
 
     ## Using PropCheck
 
-    To use `PropCheck`, you need to add `use PropCheck` to your
-    Elixir files. This gives you access to the functions and macros
-    defined here as well as to the `property` macro, defined in
-    `PropCheck.Properties.property/4`. In most examples shown
+    To use `PropCheck`, you need to add `use PropCheck` to your Elixir
+    files. This gives you access to the functions and macros defined
+    here as well as to the `property` macro, defined in
+    `PropCheck.Properties.property/4`. To set default options for your
+    properties, you can use `use PropCheck, default_opts: [numtests:
+    50]`. `default_opts` can be a list of options defined below or a
+    function that returns a list of option. In most examples shown
     here, we directly use the `quickcheck` function, but typically you
     use the `property` macro instead to define test cases for `ExUnit`.
 
@@ -272,14 +275,20 @@ defmodule PropCheck do
     Very much of the documentation is directly taken from the
     `proper` API documentation.
     """
-    defmacro __using__(_) do
-        quote do
-            import PropCheck
-            import PropCheck.Properties
-            # import :proper_types, except: [lazy: 1, to_binary: 1, function: 2]
-            import PropCheck.BasicTypes
-            import PropCheck.TargetedPBT
-        end
+    defmacro __using__(opts) do
+      default_opts = Keyword.get(opts, :default_opts, [:quiet])
+      if __CALLER__.module do
+        Module.put_attribute(__CALLER__.module,
+          :propcheck_default_opts, default_opts)
+      end
+
+      quote do
+        import PropCheck
+        import PropCheck.Properties
+        # import :proper_types, except: [lazy: 1, to_binary: 1, function: 2]
+        import PropCheck.BasicTypes
+        import PropCheck.TargetedPBT
+      end
     end
 
     @type counterexample :: :proper.counterexample

--- a/test/properties_default_opts_function.exs
+++ b/test/properties_default_opts_function.exs
@@ -1,0 +1,10 @@
+defmodule PropertiesDefaultOptsFunctionTest do
+  alias PropCheck.Test
+  use ExUnit.Case
+  use PropCheck, default_opts: &DefaultOpts.config/0
+
+  property "default_opts function returns options", [max_size: 1] do
+    assert_received :default_opts_is_ran
+    assert Process.get(:property_opts) == [max_size: 1, numtests: 1]
+  end
+end

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -1,6 +1,6 @@
 defmodule PropertiesTest do
   use ExUnit.Case
-  use PropCheck
+  use PropCheck, default_opts: [numtests: 1]
 
   setup do
     [generator: nat()]
@@ -10,5 +10,9 @@ defmodule PropertiesTest do
     forall n <- context.generator do
       is_integer(n)
     end
+  end
+
+  property "default options are set", [max_size: 1] do
+    assert Process.get(:property_opts) == [max_size: 1, numtests: 1]
   end
 end

--- a/test/support/default_opts.ex
+++ b/test/support/default_opts.ex
@@ -1,0 +1,8 @@
+defmodule PropCheck.Test.DefaultOpts do
+  @moduledoc false
+
+  def config do
+    send self(), :default_opts_is_ran
+    [numtests: 1]
+  end
+end


### PR DESCRIPTION
Removes a lot of boilerplate if all properties in test suite share the same set of options.

Another use case for this is that I'd like to have a quick and quiet tests on my local machine but a big number of verbose tests on CI server. This can be done by passing a function that reads options from system envs.