### PR TITLE
Allow setting verbose in environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ independent from the build environment, in the file `propcheck.ctex`. The file c
 be removed using `mix propcheck.clean`. Note that this task is only available if PropCheck
 is also available in `:dev`. Otherwise, `MIX_ENV=test mix propcheck.clean` can be used.
 
+### Setting PropCheck into Verbose Mode
+
+Properties in PropCheck can be run in quiet or verbose mode. Usually, quiet is the default. To
+enable verbose mode without requiring to touch the source code, the environment variable `PROPCHECK_VERBOSE`
+can be used. If this is set to 1, the `forall` macro prints verbose output.
 
 ## Links to other documentation
 

--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -393,7 +393,9 @@ defmodule PropCheck do
     defp forall_impl(var, rawtype, opts, prop) do
       quote do
         property_opts = Process.get(:property_opts, [])
-        verbose = :verbose in property_opts || :verbose in unquote(opts)
+        env_verbose? = System.get_env("PROPCHECK_VERBOSE") == "1"
+        verbose =
+          :verbose in property_opts || :verbose in unquote(opts) || env_verbose?
         :proper.forall(
           unquote(rawtype),
           fn(unquote(var)) ->

--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -270,6 +270,11 @@ defmodule PropCheck do
     * `{:unrecognized_option, option}`<br>
       `option` is not an option that PropEr understands.
 
+    ## Commandline Options
+
+    As noted above, `:verbose` can be used to enable verbose output. This can also be
+    achieved using the environment variable `PROPCHECK_VERBOSE`.
+
     ## Acknowledgments
 
     Very much of the documentation is directly taken from the
@@ -377,6 +382,11 @@ defmodule PropCheck do
         false
 
     Use `:verbose` to enable output on failed `ExUnit` assertions.
+
+    ## Setting Verbosity on the Command Line
+
+    Apart from setting `:verbose` explicitly in the source code, the `PROPCHECK_VERBOSE`
+    environment variable can also be used to set the tests into verbose mode.
 
     """
     @in_ops [:<-, :in]


### PR DESCRIPTION
This pull request adds the option to set verbosity using the environment with the `VERBOSE` variable:

```
$ VERBOSE=1 mix test
```

Fix #117 