### PR TITLE
Fix handling tags (fix #106)

### DIFF
--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -92,9 +92,11 @@ defmodule PropCheck.Properties do
           %{module: module} = __ENV__
 
           module_default_opts = Module.get_attribute(module, :propcheck_default_opts) || [:quiet]
-          moduletag = Module.get_attribute(module, :moduletag) |> List.flatten()
-          describetag = Module.get_attribute(module, :describetag) |> List.flatten()
-          tag = Module.get_attribute(module, :tag) |> List.flatten()
+
+          # Get the attributes and allow using the Keyword module by filtering for tuple entries in the tags
+          moduletag = Module.get_attribute(module, :moduletag) |> List.flatten() |> Enum.filter(&is_tuple/1)
+          describetag = Module.get_attribute(module, :describetag) |> List.flatten() |> Enum.filter(&is_tuple/1)
+          tag = Module.get_attribute(module, :tag) |> List.flatten() |> Enum.filter(&is_tuple/1)
 
           # intended precedence: tag > describetag > moduletag
           store_counter_example =


### PR DESCRIPTION
The pull request #106 introduced an error when moduletag/describetag/tag is present. ExUnit allows tags to be single atoms, but we use functions from the Keyword module within `lib/properties.ex`. Those functions fail if non-2-tuple elements are stored inside any tag.

For example, this module results in a compile error before this change:

```elixir
defmodule StoreCounterExample.DescribeTag do
  use ExUnit.Case
  use PropCheck
  @moduletag :capture_log

  describe "store counter example with describe" do
    @describetag store_counter_example: false

    @tag will_fail: true
    property "failing" do
      forall n <- integer(0, :inf) do
        n < 0
      end
    end
  end
end
```

```
mix test test/fail.exs
Compiling 2 files (.ex)

== Compilation error in file test/fail.exs ==
** (ArgumentError) expected a keyword list as the first argument, got: [:capture_log]
    (elixir) lib/keyword.ex:721: anonymous fn/3 in Keyword.merge/2
    (elixir) lib/keyword.ex:725: Keyword."-merge/2-lists^filter/1-0-"/2
    (elixir) lib/keyword.ex:725: Keyword.merge/2
    test/fail.exs:10: (module)
    (stdlib) erl_eval.erl:680: :erl_eval.do_apply/6
    (elixir) lib/kernel/parallel_compiler.ex:237: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/7
[1]    48742 exit 1     mix test test/fail.exs
```

With the changes here, the example works again.

@alfert As this bug currently breaks user code, merging this should result in a new release.
@jvf Thanks for noticing this bug.