### PR TITLE
Enable PROPCHECK_VERBOSE on properties

### DIFF
--- a/.travis-scripts/verify-verbose.sh
+++ b/.travis-scripts/verify-verbose.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Verify that PROPCHECK_VERBOSE works as intended.
+#
+
+search_for="Passed 100 test(s)"
+quiet=$(mix test test/verify_verbose_test.exs)
+verbose=$(PROPCHECK_VERBOSE=1 mix test test/verify_verbose_test.exs)
+
+if echo $quiet | grep "$search_for" -q; then
+    echo >&2 "Found '$search_for' when it should be quiet"
+    echo >&2 "Output:"
+    echo >&2 $quiet
+    exit 1
+fi
+
+if ! echo $verbose | grep "$search_for" -q; then
+    echo >&2 "Did not find '$search_for' when it should be verbose"
+    echo >&2 "Output:"
+    echo >&2 $verbose
+    exit 2
+fi

--- a/.travis-scripts/verify-verbose.sh
+++ b/.travis-scripts/verify-verbose.sh
@@ -3,20 +3,32 @@
 # Verify that PROPCHECK_VERBOSE works as intended.
 #
 
-search_for="Passed 100 test(s)"
-quiet=$(mix test test/verify_verbose_test.exs)
-verbose=$(PROPCHECK_VERBOSE=1 mix test test/verify_verbose_test.exs)
+search_for="OK: Passed 100 test(s)"
+no_global_verbose=$(mix test test/verify_verbose_test.exs)
+global_quiet=$(PROPCHECK_VERBOSE=0 mix test test/verify_verbose_test.exs)
+global_verbose=$(PROPCHECK_VERBOSE=1 mix test test/verify_verbose_test.exs)
 
-if echo $quiet | grep "$search_for" -q; then
-    echo >&2 "Found '$search_for' when it should be quiet"
+count_output_no_global_verbose=$(echo "$no_global_verbose" | grep -c "$search_for")
+count_output_global_quiet=$(echo "$global_quiet" | grep -c "$search_for")
+count_output_global_verbose=$(echo "$global_verbose" | grep -c "$search_for")
+
+if [ "$count_output_no_global_verbose" -ne 1 ]; then
+    echo >&2 "Found '$search_for' more than once when it should exist only once"
     echo >&2 "Output:"
-    echo >&2 $quiet
+    echo >&2 "$no_global_verbose"
     exit 1
 fi
 
-if ! echo $verbose | grep "$search_for" -q; then
-    echo >&2 "Did not find '$search_for' when it should be verbose"
+if [ "$count_output_global_quiet" -ne 0 ]; then
+    echo >&2 "Found '$search_for' when it should be quiet"
     echo >&2 "Output:"
-    echo >&2 $verbose
+    echo >&2 "$global_quiet"
     exit 2
+fi
+
+if [ "$count_output_global_verbose" -ne 2 ]; then
+    echo >&2 "Found '$search_for' only $count_output_global_verbose times when it should be 2"
+    echo >&2 "Output:"
+    echo >&2 "$global_verbose"
+    exit 3
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ before_script:
 script:
   - mix test --cover --trace --exclude will_fail:true --exclude unstable_test:true
   - ./.travis-scripts/verify_storing_counterexamples.sh
+  - ./.travis-scripts/verify-verbose.sh
   - mix credo --strict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PropCheck Changelog
 
+## 1.2.1
+
+* Fix `PROPCHECK_VERBOSE` to work with `property`
+* Allow `PROPCHECK_VERBOSE=0` to make all properties quiet
+
 ## 1.2.0
 * Handling of tags corrected. This changes slighty existing the behavior and gives
   reason to introduce a new minor version. 

--- a/lib/app.ex
+++ b/lib/app.ex
@@ -9,6 +9,8 @@ defmodule PropCheck.App do
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
+    populate_application_env()
+
     children = [
       # Define workers and child supervisors to be supervised
       # worker(PropCheck.Worker, [arg1, arg2, arg3])
@@ -20,5 +22,9 @@ defmodule PropCheck.App do
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Propcheck.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  defp populate_application_env do
+    Application.put_env(:propcheck, :verbose, System.get_env("PROPCHECK_VERBOSE") == "1")
   end
 end

--- a/lib/app.ex
+++ b/lib/app.ex
@@ -25,6 +25,16 @@ defmodule PropCheck.App do
   end
 
   defp populate_application_env do
-    Application.put_env(:propcheck, :verbose, System.get_env("PROPCHECK_VERBOSE") == "1")
+    Application.put_env(:propcheck, :global_verbose,  global_verbose())
+  end
+
+  defp global_verbose do
+      "PROPCHECK_VERBOSE"
+      |> System.get_env()
+      |> case do
+        "1" -> true
+        "0" -> false
+        _ -> nil
+      end
   end
 end

--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -402,10 +402,13 @@ defmodule PropCheck do
 
     defp forall_impl(var, rawtype, opts, prop) do
       quote do
-        property_opts = Process.get(:property_opts, [])
-        env_verbose? = System.get_env("PROPCHECK_VERBOSE") == "1"
-        verbose =
-          :verbose in property_opts || :verbose in unquote(opts) || env_verbose?
+        opts =
+          PropCheck.Utils.get_opts()
+          |> PropCheck.Utils.merge(unquote(opts))
+          |> PropCheck.Utils.put_opts()
+
+        verbose? = :verbose in opts
+
         :proper.forall(
           unquote(rawtype),
           fn(unquote(var)) ->
@@ -414,7 +417,7 @@ defmodule PropCheck do
             rescue
               e in ExUnit.AssertionError ->
                 stacktrace = System.stacktrace
-                if verbose do
+                if verbose? do
                   e |> ExUnit.AssertionError.message() |> IO.write()
                   formatted = Exception.format_stacktrace(stacktrace)
                   IO.puts("stacktrace:\n#{formatted}")

--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -385,8 +385,10 @@ defmodule PropCheck do
 
     ## Setting Verbosity on the Command Line
 
-    Apart from setting `:verbose` explicitly in the source code, the `PROPCHECK_VERBOSE`
-    environment variable can also be used to set the tests into verbose mode.
+    Apart from setting `:verbose` or `:quiet` explicitly in the source code,
+    the `PROPCHECK_VERBOSE` environment variable can also be used to set the
+    verbosity. `PROPCHECK_VERBOSE=1` sets `:verbose`, while `PROPCHECK_VERBOSE=0`
+    sets `:quiet`.
 
     """
     @in_ops [:<-, :in]

--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -407,7 +407,7 @@ defmodule PropCheck do
           |> PropCheck.Utils.merge(unquote(opts))
           |> PropCheck.Utils.put_opts()
 
-        verbose? = :verbose in opts
+        verbose? = PropCheck.Utils.verbose?(opts)
 
         :proper.forall(
           unquote(rawtype),

--- a/lib/propcheck/utils.ex
+++ b/lib/propcheck/utils.ex
@@ -5,15 +5,13 @@ defmodule PropCheck.Utils do
   # `PropCheck.check/2` with global options. Global options
   # take precedence.
   def merge_global_opts(local_opts) do
-    global_verbose? = System.get_env("PROPCHECK_VERBOSE") == "1"
-
-    if global_verbose? do
+    if Application.get_env(:propcheck, :verbose) do
       [:verbose | local_opts]
     else
       local_opts
     end
   end
-  
+
   # Merge options
   def merge(opts1, opts2) do
     opts1

--- a/lib/propcheck/utils.ex
+++ b/lib/propcheck/utils.ex
@@ -5,10 +5,13 @@ defmodule PropCheck.Utils do
   # `PropCheck.check/2` with global options. Global options
   # take precedence.
   def merge_global_opts(local_opts) do
-    if Application.get_env(:propcheck, :verbose) do
-      [:verbose | local_opts]
-    else
-      local_opts
+    case Application.get_env(:propcheck, :global_verbose) do
+      true ->
+        [:verbose | local_opts]
+      false ->
+        [:quiet | local_opts]
+      nil ->
+        local_opts
     end
   end
 
@@ -28,5 +31,20 @@ defmodule PropCheck.Utils do
   # Retrieve stored options from the process dictionary.
   def get_opts do
     Process.get(:property_opts, []) || []
+  end
+
+  # Check if verbose should be enabled
+  def verbose?(opts) do
+    verbose_index = Enum.find_index(opts, & &1 == :verbose)
+    if verbose_index do
+      quiet_index = Enum.find_index(opts, & &1 == :quiet)
+      if quiet_index do
+        verbose_index < quiet_index
+      else
+        true
+      end
+    else
+      false
+    end
   end
 end

--- a/lib/propcheck/utils.ex
+++ b/lib/propcheck/utils.ex
@@ -1,0 +1,42 @@
+defmodule PropCheck.Utils do
+  @moduledoc false
+
+  @doc """
+  Merge local options for `PropCheck.quickcheck/2` and
+  `PropCheck.check/2` with global options. Global options
+  take precedence.
+  """
+  def merge_global_opts(local_opts) do
+    global_verbose? = System.get_env("PROPCHECK_VERBOSE") == "1"
+
+    if global_verbose? do
+      [:verbose | local_opts]
+    else
+      local_opts
+    end
+  end
+
+  @doc """
+  Merge options.
+  """
+  def merge(opts1, opts2) do
+    opts1
+    |> Enum.concat(opts2)
+    |> Enum.uniq()
+  end
+
+  @doc """
+  Store options in the process dictionary for later retrieval.
+  """
+  def put_opts(opts) do
+    Process.put(:property_opts, opts)
+    opts
+  end
+
+  @doc """
+  Retrieve stored options from the process dictionary.
+  """
+  def get_opts do
+    Process.get(:property_opts, []) || []
+  end
+end

--- a/lib/propcheck/utils.ex
+++ b/lib/propcheck/utils.ex
@@ -1,11 +1,9 @@
 defmodule PropCheck.Utils do
   @moduledoc false
 
-  @doc """
-  Merge local options for `PropCheck.quickcheck/2` and
-  `PropCheck.check/2` with global options. Global options
-  take precedence.
-  """
+  # Merge local options for `PropCheck.quickcheck/2` and
+  # `PropCheck.check/2` with global options. Global options
+  # take precedence.
   def merge_global_opts(local_opts) do
     global_verbose? = System.get_env("PROPCHECK_VERBOSE") == "1"
 
@@ -15,27 +13,21 @@ defmodule PropCheck.Utils do
       local_opts
     end
   end
-
-  @doc """
-  Merge options.
-  """
+  
+  # Merge options
   def merge(opts1, opts2) do
     opts1
     |> Enum.concat(opts2)
     |> Enum.uniq()
   end
 
-  @doc """
-  Store options in the process dictionary for later retrieval.
-  """
+  # Store options in the process dictionary for later retrieval.
   def put_opts(opts) do
     Process.put(:property_opts, opts)
     opts
   end
 
-  @doc """
-  Retrieve stored options from the process dictionary.
-  """
+  # Retrieve stored options from the process dictionary.
   def get_opts do
     Process.get(:property_opts, []) || []
   end

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -109,22 +109,13 @@ defmodule PropCheck.Properties do
           tags = [[failing_prop: tag_property({module, name, []})]]
           prop_name = ExUnit.Case.register_test(__ENV__, :property, name, tags)
           def unquote(prop_name)(unquote(var)) do
-            merged_opts = PropCheck.Properties.merge_opts(unquote(opts), unquote(module_default_opts))
+            merged_opts =
+              PropCheck.Properties.merge_opts(unquote(opts), unquote(module_default_opts))
+              |> PropCheck.Utils.merge_global_opts()
+              |> PropCheck.Utils.put_opts()
 
-            # Store opts in process dictionary to make them available within macros such
-            # as forall
-            Process.put(:property_opts, merged_opts)
             p = unquote(block)
             mfa = {unquote(module), unquote(prop_name), []}
-
-            env_verbose? = System.get_env("PROPCHECK_VERBOSE") == "1"
-
-            merged_opts =
-              if env_verbose? do
-                [:verbose | merged_opts]
-              else
-                merged_opts
-              end
 
             execute_property(p, mfa, merged_opts, unquote(store_counter_example))
             :ok

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -116,6 +116,16 @@ defmodule PropCheck.Properties do
             Process.put(:property_opts, merged_opts)
             p = unquote(block)
             mfa = {unquote(module), unquote(prop_name), []}
+
+            env_verbose? = System.get_env("PROPCHECK_VERBOSE") == "1"
+
+            merged_opts =
+              if env_verbose? do
+                [:verbose | merged_opts]
+              else
+                merged_opts
+              end
+
             execute_property(p, mfa, merged_opts, unquote(store_counter_example))
             :ok
           end

--- a/test/verify_verbose_test.exs
+++ b/test/verify_verbose_test.exs
@@ -10,4 +10,10 @@ defmodule VerifyVerbose do
       x >= 0
     end
   end
+
+  property "some other property", [:verbose] do
+    forall x <- nat() do
+      x >= 0
+    end
+  end
 end

--- a/test/verify_verbose_test.exs
+++ b/test/verify_verbose_test.exs
@@ -1,0 +1,13 @@
+defmodule VerifyVerbose do
+  # Check that setting verboseness using PROPCHECK_VERBOSE works as intended.
+  use ExUnit.Case
+  use PropCheck
+
+  @moduletag :manual
+
+  property "some property", [:quiet] do
+    forall x <- nat() do
+      x >= 0
+    end
+  end
+end


### PR DESCRIPTION
In https://github.com/alfert/propcheck/pull/118, we implemented the environment variable `PROPCHECK_VERBOSE` to set the verbosity on the command line. Alas, this variable does not currently apply to properties. We need to pass the verbosity into the options there to make this work fully.

@alfert This fix feels rather hacky. What do you think, how should this be solved?