### PR TITLE
Fix deprecation warning for Kernel.Typespec.beam_types/1

### DIFF
--- a/test/propcheck_test.exs
+++ b/test/propcheck_test.exs
@@ -13,7 +13,7 @@ defmodule PropcheckTest do
   @type tagged_stack(t) :: {:stack, [t]}
 
   test "find types in proper_gen.erl" do
-    types = Kernel.Typespec.beam_types(:proper_gen)
+    types = Code.Typespec.fetch_types(:proper_gen)
     refute nil == types
 
     Logger.debug(inspect types, pretty: true)


### PR DESCRIPTION
This fixes a deprecation warning for `Kernel.Typespec.beam_types/1`:

```
warning: Kernel.Typespec.beam_types/1 is deprecated. Use Code.Typespec.fetch_types/1 instead
  test/propcheck_test.exs:16
```

As can be seen in [this](https://travis-ci.org/evnu/propcheck/builds/597847058) pipeline, this raises the minimum Elixir version to v1.7.

@alfert This deprecation is not urgent, feel free to close the PR.