### PR TITLE
Allow configuring counter examples path in config/

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ def project() do
 end
 ```
 
+Note that the path can also be set as part of the application environment:
+
+```
+config :propcheck, counter_examples: "filename"
+```
+
+If both the project configuration and the application environment are present, the
+application environment is chosen.
+
 Per default, the counter examples file is stored in the build directory (`_build`),
 independent from the build environment, in the file `propcheck.ctex`. The file can
 be removed using `mix propcheck.clean`. Note that this task is only available if PropCheck

--- a/lib/app.ex
+++ b/lib/app.ex
@@ -17,7 +17,7 @@ defmodule PropCheck.App do
         start: {
           PropCheck.CounterStrike,
           :start_link,
-          [Mix.counter_example_file(), [name: PropCheck.CounterStrike]]
+          [[name: PropCheck.CounterStrike]]
         }
       }
     ]
@@ -31,6 +31,7 @@ defmodule PropCheck.App do
   defp populate_application_env do
     Application.put_env(:propcheck, :global_verbose,  global_verbose())
     Application.put_env(:propcheck, :global_detect_exceptions,  global_detect_exceptions())
+    Application.put_env(:propcheck, :counter_example_file, counter_example_file())
   end
 
   defp global_verbose do
@@ -43,6 +44,13 @@ defmodule PropCheck.App do
       "PROPCHECK_DETECT_EXCEPTIONS"
       |> System.get_env()
       |> env_to_terniary()
+  end
+
+  defp counter_example_file do
+    case Application.get_env(:propcheck, :counter_examples) do
+      nil -> Mix.counter_example_file() || Mix.default_counter_examples_file()
+      counter_example_file -> counter_example_file
+    end
   end
 
   defp env_to_terniary("1"), do: true

--- a/lib/counterstrike.ex
+++ b/lib/counterstrike.ex
@@ -17,8 +17,18 @@ defmodule PropCheck.CounterStrike do
 
   defstruct [counter_examples: %{}, dets: nil]
 
-  def start_link(filename \\ 'propcheck.dets', opts \\ [])
-  def start_link(filename, opts) when is_binary(filename), do: start_link(String.to_charlist(filename), opts)
+  def start_link(opts) do
+    :propcheck
+    |> Application.get_env(:counter_example_file)
+    |> start_link(opts)
+  end
+
+  def start_link(filename, opts) when is_binary(filename) do
+    filename
+    |> String.to_charlist()
+    |> start_link(opts)
+  end
+
   def start_link(filename, opts) when is_list(filename) do
     # Logger.info "Filename: #{filename}, options: #{inspect opts}"
     GenServer.start_link(__MODULE__, [filename], opts)

--- a/lib/mix.ex
+++ b/lib/mix.ex
@@ -1,14 +1,14 @@
 defmodule PropCheck.Mix do
   @moduledoc false
 
+  def default_counter_examples_file do
+    Mix.Project.build_path()
+    |> Path.dirname()
+    |> Path.join("propcheck.ctex")
+  end
+
   def counter_example_file do
-    default_path =
-      Mix.Project.build_path()
-      |> Path.dirname()
-      |> Path.join("propcheck.ctex")
-    Mix.Project.config()
-    |> Keyword.get(:propcheck, [counter_examples: default_path])
-    |> Keyword.get(:counter_examples)
+    get_in(Mix.Project.config(), [:propcheck, :counter_examples])
   end
 end
 

--- a/test/counterstrike_test.exs
+++ b/test/counterstrike_test.exs
@@ -5,7 +5,7 @@ defmodule PropCheck.Test.CounterStrikeTest do
   """
   use ExUnit.Case, async: true
   use PropCheck, default_opts: &PropCheck.TestHelpers.config/0
-  import PropCheck.TestHelpers, only: [debugln: 1]
+  import PropCheck.TestHelpers, only: [debugln: 1, config: 0]
   require Logger
 
   alias PropCheck.CounterStrike
@@ -15,7 +15,7 @@ defmodule PropCheck.Test.CounterStrikeTest do
     filename = "counterstrike_test.#{System.unique_integer([:positive, :monotonic])}.dets"
     path = Path.join(Mix.Project.build_path(), filename)
     File.rm(path)
-    {:ok, pid} = CounterStrike.start_link(path)
+    {:ok, pid} = CounterStrike.start_link(path, [])
     # on_exit(fn() -> File.rm!(path) end)
     {:ok, %{pid: pid, path: path}}
   end
@@ -31,7 +31,7 @@ defmodule PropCheck.Test.CounterStrikeTest do
     CounterStrike.stop(org_pid)
     wait_for_stop(ref)
 
-    {:ok, pid} = CounterStrike.start_link(path)
+    {:ok, pid} = CounterStrike.start_link(path, [])
     assert :others == CounterStrike.counter_example(pid, {:foo, :bar, 1})
     assert {:ok, []} == CounterStrike.counter_example(pid, {:foo, :bar, 0})
     ref = Process.monitor(pid)


### PR DESCRIPTION
This pull request extends configuration to store counter examples to the application environment. Now, the following is possible:

```elixir
config :propcheck, counter_examples: "location"
```

If the path is configured both in the project definition as well as in the application environment, the application environment takes precedence. As before, it is configured in neither location, it takes a default value.

Fix #115 