### PR TITLE
Translate terms in output from Erlang to Elixir syntax

### DIFF
--- a/.travis-scripts/verify-verbose-in-elixir-syntax.sh
+++ b/.travis-scripts/verify-verbose-in-elixir-syntax.sh
@@ -9,9 +9,9 @@ seed=0
 elixir_syntax_output=$(mix test --seed 0 test/verify_verbose_elixir_syntax_test.exs)
 
 # linked process crashes
-expected='A linked process died with reason: an exception was raised:
-** (ArithmeticError) bad argument in arithmetic expression'
-if [[ ! $elixir_syntax_output =~ "$expected" ]]; then
+expected1='A linked process died with reason: an exception was raised:'
+expected2='** (ArithmeticError) bad argument in arithmetic expression'
+if ! echo "$elixir_syntax_output" | grep -FA1 "$expected1" | grep -qF "$expected2"; then
     echo >&2 "Crash report from linked process not found"
     echo >&2 "Output:"
     echo >&2 "$elixir_syntax_output"
@@ -20,7 +20,7 @@ fi
 
 # linked process kills it self
 expected='A linked process died with reason :killed.'
-if [[ ! $elixir_syntax_output =~ "$expected" ]]; then
+if ! echo "$elixir_syntax_output" | grep -qF "$expected"; then
     echo >&2 "Crash report from linked process not found"
     echo >&2 "Output:"
     echo >&2 "$elixir_syntax_output"
@@ -29,20 +29,29 @@ fi
 
 # collect prints Elixir syntax
 expected='100% %{test: VerifyVerboseElixirSyntaxTest}'
-if [[ ! $elixir_syntax_output =~ "$expected" ]]; then
+if ! echo "$elixir_syntax_output" | grep -qF "$expected"; then
     echo >&2 "Collected categories not found"
     echo >&2 "Output:"
     echo >&2 "$elixir_syntax_output"
     exit 1
 fi
 
+# exception was raised on test crash
+expected1='An exception was raised:'
+expected2='** (RuntimeError) test crash'
+if ! echo "$elixir_syntax_output" | grep -FA1 "$expected1" | grep -qF "$expected2"; then
+    echo >&2 "Raised exception on test crash not found"
+    echo >&2 "Output:"
+    echo >&2 "$elixir_syntax_output"
+    exit 1
+fi
+
+
 # exception was raised with stacktrace
-expected='An exception was raised:
-** (RuntimeError) test crash
-Stacktrace:
-    test/verify_verbose_elixir_syntax_test.exs:'
-if [[ ! $elixir_syntax_output =~ "$expected" ]]; then
-    echo >&2 "Collected categories not found"
+expected1='Stacktrace:'
+expected2='    test/verify_verbose_elixir_syntax_test.exs:'
+if ! echo "$elixir_syntax_output" | grep -FA1 "$expected1" | grep -qF "$expected2"; then
+    echo >&2 "Raised exception with stacktrace not found"
     echo >&2 "Output:"
     echo >&2 "$elixir_syntax_output"
     exit 1

--- a/.travis-scripts/verify-verbose-in-elixir-syntax.sh
+++ b/.travis-scripts/verify-verbose-in-elixir-syntax.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Test that verbose output is printed in Elixir syntax.
+#
+
+# run tests in order
+seed=0
+
+elixir_syntax_output=$(mix test --seed 0 test/verify_verbose_elixir_syntax_test.exs)
+
+# linked process crashes
+expected='A linked process died with reason: an exception was raised:
+** (ArithmeticError) bad argument in arithmetic expression'
+if [[ ! $elixir_syntax_output =~ "$expected" ]]; then
+    echo >&2 "Crash report from linked process not found"
+    echo >&2 "Output:"
+    echo >&2 "$elixir_syntax_output"
+    exit 1
+fi
+
+# linked process kills it self
+expected='A linked process died with reason :killed.'
+if [[ ! $elixir_syntax_output =~ "$expected" ]]; then
+    echo >&2 "Crash report from linked process not found"
+    echo >&2 "Output:"
+    echo >&2 "$elixir_syntax_output"
+    exit 1
+fi
+
+# collect prints Elixir syntax
+expected='100% %{test: VerifyVerboseElixirSyntaxTest}'
+if [[ ! $elixir_syntax_output =~ "$expected" ]]; then
+    echo >&2 "Collected categories not found"
+    echo >&2 "Output:"
+    echo >&2 "$elixir_syntax_output"
+    exit 1
+fi
+
+# exception was raised with stacktrace
+expected='An exception was raised:
+** (RuntimeError) test crash
+Stacktrace:
+    test/verify_verbose_elixir_syntax_test.exs:'
+if [[ ! $elixir_syntax_output =~ "$expected" ]]; then
+    echo >&2 "Collected categories not found"
+    echo >&2 "Output:"
+    echo >&2 "$elixir_syntax_output"
+    exit 1
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,5 @@ script:
   - ./.travis-scripts/verify_storing_counterexamples.sh
   - ./.travis-scripts/verify-verbose.sh
   - ./.travis-scripts/verify-detect-exceptions.sh
+  - ./.travis-scripts/verify-verbose-in-elixir-syntax.sh
   - mix credo --strict

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -113,7 +113,8 @@ defmodule PropCheck.Properties do
             opts = [{:output_agent, output_agent} | unquote(opts)]
 
             merged_opts =
-              PropCheck.Properties.merge_opts(opts, unquote(module_default_opts))
+              opts
+              |> PropCheck.Properties.merge_opts(unquote(module_default_opts))
               |> PropCheck.Utils.merge_global_opts()
               |> PropCheck.Utils.put_opts()
 

--- a/test/verify_verbose_elixir_syntax_test.exs
+++ b/test/verify_verbose_elixir_syntax_test.exs
@@ -1,0 +1,40 @@
+defmodule VerifyVerboseElixirSyntaxTest do
+  use ExUnit.Case, async: false
+  use PropCheck, default_opts: [:verbose]
+
+  @moduletag :will_fail
+
+  property "linked process crashes" do
+    trap_exit(forall n <- nat() do
+      # this must fail
+      _pid = spawn_link(fn() -> n / 0 end)
+      # wait for arrivial of the dieing linked process signal
+      :timer.sleep(50)
+      false
+    end)
+  end
+
+  property "linked process kills it self" do
+    trap_exit(forall _n <- nat() do
+               # this must fail
+               _pid = spawn_link(fn() -> Process.exit(self(), :kill) end)
+               # wait for arrivial of the dieing linked process signal
+               :timer.sleep(50)
+               true #
+    end)
+  end
+
+  @tag :manual
+  property "collect prints Elixir syntax" do
+    forall _n <- nat() do
+      true
+      |> collect(%{test: __MODULE__})
+    end
+  end
+
+  property "exception was raised with stacktrace" do
+    forall _x <- nat() do
+      raise "test crash"
+    end
+  end
+end


### PR DESCRIPTION
PropEr outputs terms in Erlang syntax, and by extension so does
PropCheck. Although it outputs just a subset of Erlang syntax (just the
terms) and reading them is generally not a problem (and even a useful
skill), it can be a pain when trying to copy it to IEx shell. Also it
might discourage new users from using PropCheck.

This commit fixes that. It does this by providing a default function for
`:on_output` option as a translator function. It also touches how
`:verbose` option is processed. That is because PropEr uses _on_output_
functionality for both `:silent` and `:verbose` options by either
supplying a "no print" or "print all in Erlang syntax" functions. That's
why whenever a `:verbose` option is provided to one of functions/macros
we need to substitute `:verbose` for our custom "print all in Elixir
syntax" function - `PropCheck.Utils.elixirfy_output/2`.