### PR TITLE
Add pretty reports for StateM

### DIFF
--- a/lib/statem.ex
+++ b/lib/statem.ex
@@ -392,4 +392,23 @@ defmodule PropCheck.StateM do
   """
   defdelegate zip(l1, l2), to: :proper_statem
 
+  @doc """
+  Print pretty report of the failed command run.
+
+  Accepts options:
+  * `return_values` - whether to print return values after each command run
+    (default `true`),
+  * `last_state` - whether section with the last state should be present
+    (default `true`),
+  * `pre_cmd_state` - whether to print state prior to executed command
+    (default `false`),
+  * `post_cmd_state` - whether to print state post executed command
+    (default `true`),
+  * `cmd_args` - whether to print command arguments as literals
+    (default `true`),
+  * `inspect_opts` - options passed to `inspect/2`
+
+  """
+  defdelegate print_report(run_result, cmds, opts \\ []),
+    to: PropCheck.StateM.Reporter
 end

--- a/lib/statem/report.ex
+++ b/lib/statem/report.ex
@@ -1,0 +1,243 @@
+defmodule PropCheck.StateM.Reporter do
+  @moduledoc false
+
+  def print_report({history, state, result}, commands, opts \\ []),
+    do: pretty_report(result, history, state, commands, opts)
+
+  defp pretty_report(:ok, history, state, commands, opts),
+    do: print_pretty_report(
+          "All commands were successful and all postconditions were true.",
+          :all, history, state, commands, opts
+        )
+
+  defp pretty_report(:initialization_error, history, state, commands, opts),
+    do: print_pretty_report("Error while evaluating initial state.", :none,
+      history, state, commands, opts)
+
+  defp pretty_report({:precondition, false}, history, state, commands, opts) do
+    failing_cmd_idx = {:fail_at, length(history)}
+    print_pretty_report("Precondition failed.", failing_cmd_idx,
+      history, state, commands, opts)
+  end
+
+  defp pretty_report({:precondition, exp = {:exception, _, _, _}}, history,
+    state, commands, opts) do
+    failing_cmd_idx = {:fail_at, length(history)}
+    title =  "Precondition crashed:\n" <> inspectx(exp, opts)
+    print_pretty_report(title, failing_cmd_idx, history, state, commands, opts)
+  end
+
+  defp pretty_report({:postcondition, false}, history, state, commands, opts) do
+    failing_cmd_idx = {:fail_at, length(history) - 1}
+    print_pretty_report("Postcondition failed.", failing_cmd_idx,
+      history, state, commands, opts)
+  end
+
+  defp pretty_report({:postcondition, exp = {:exception, _, _, _}}, history,
+    state, commands, opts) do
+    failing_cmd_idx = {:fail_at, length(history) - 1}
+    title =  "Postcondition crashed:\n#{inspectx(exp, opts)}"
+    print_pretty_report(title, failing_cmd_idx, history, state, commands, opts)
+  end
+
+  defp pretty_report(exp = {:exception, _, _, _}, history, state, commands, opts) do
+    failing_cmd_idx = {:fail_at, length(history)}
+    history = history ++ [{state, exp}]
+    print_pretty_report("Command crashed.", failing_cmd_idx, history, state,
+      commands, opts)
+  end
+
+  @header String.duplicate("=", 80)
+  defp print_pretty_report(title, cmds_to_print, history, state, commands, opts) do
+    main = main_section(cmds_to_print, history, state, commands, opts)
+    IO.puts """
+
+    #{@header}
+    #{title}
+
+    #{main}
+    """
+  end
+
+  defp main_section(cmds_to_print, history, state, commands, opts)
+  defp main_section(:none, _history, _state, _commands, _opts),
+    do: ""
+  defp main_section(:all, history, state, commands, opts) do
+    history_commands = zip_cmds_history(commands, history)
+    last_state = last_state_section(state, opts)
+    cmds = history_commands |> print_command_lines(false, opts) |> Enum.join("\n")
+
+    """
+    Commands:
+    #{cmds}
+    #{last_state}
+    """
+  end
+  defp main_section({:fail_at, cmd_idx}, history, state, commands, opts) do
+    history_commands = zip_cmds_history(commands, history)
+    last_state = last_state_section(state, opts)
+
+    # commands before the failing one
+    priori_cmds =
+      history_commands
+      |> Enum.take(cmd_idx)
+      |> print_command_lines(false, opts)
+
+    # failing command
+    failing_cmd =
+      history_commands
+      |> Enum.at(cmd_idx)
+      |> print_command_line(true, opts)
+
+    cmds = Enum.join priori_cmds ++ [failing_cmd], "\n"
+    """
+    Commands:
+    #{cmds}
+    #{last_state}
+    """
+  end
+
+  defp last_state_section(state, opts) do
+    case Keyword.get(opts, :last_state, true) do
+      true ->
+        """
+
+        Last state:
+        #{inspectx state, opts}
+        """
+      false -> ""
+    end
+  end
+
+  defp zip_cmds_history(commands, history) do
+    zipper = fn cmd, acc ->
+      case acc do
+        {[], zipped} ->
+          {[], [{cmd, nil} | zipped]}
+
+        {[{pre_state, return_val}], zipped} ->
+          post_state = nil
+          {[], [{cmd, {return_val, pre_state, post_state}} | zipped]}
+
+        {[{pre_state, return_val}, h = {post_state, _} | history], zipped} ->
+          {[h|history], [{cmd, {return_val, pre_state, {:just, post_state}}} | zipped]}
+      end
+    end
+    Enum.reduce(commands, {history, []}, zipper)
+    |> elem(1)
+    |> Enum.reverse
+  end
+
+  defp print_command_lines(hist_cmds, failing?, opts) do
+    Enum.map(hist_cmds, &print_command_line(&1, failing?, opts))
+  end
+  defp print_command_line({cmd, history}, failing?, opts) do
+    has_history? = match?({_return_val, _pre_state, _post_state}, history)
+    print_return_val? = has_history? and Keyword.get(opts, :return_values, true)
+    print_pre_state? = has_history? and Keyword.get(opts, :pre_cmd_state, false)
+    print_post_state? = has_history? and Keyword.get(opts, :post_cmd_state, true)
+
+    [
+      if(print_pre_state?, do: print_pre_state(history, opts), else: ""),
+      print_command(cmd, failing?, opts),
+      if(print_return_val?, do: print_return_value(history, opts), else: ""),
+      if(print_post_state?, do: print_post_state(history, opts), else: ""),
+    ]
+    |> to_string
+  end
+
+  defp print_command(cmd, failing?, opts)
+  defp print_command(cmd, false, opts),
+    do: indent(pretty_cmd_name(cmd, opts), 3, false) <> "\n"
+  defp print_command(cmd, true, opts) do
+    cmt =
+      [:red, "#! ", :reset]
+      |> IO.ANSI.format() |> to_string
+    cmd_str =
+      [:red, pretty_cmd_name(cmd, opts), :reset]
+      |> IO.ANSI.format() |> to_string
+    indent(cmd_str, 3, cmt) <> "\n"
+  end
+
+  defp print_return_value({return_val, _, _}, opts) do
+    comment("->", return_val, opts)
+  end
+
+  defp print_pre_state({_, pre_state, _}, opts) do
+    comment("Pre state:", pre_state, opts)
+  end
+
+  defp print_post_state({_, _, nil}, _opts), do: ""
+  defp print_post_state({_, _, {:just, post_state}}, opts) do
+    # "\n" <> comment("Post state:", post_state, opts)
+    comment("Post state:", post_state, opts)
+  end
+
+  defp comment(title, val, opts) do
+    str = inspectx(val, opts)
+      # |> String.replace("\n", "\n#{indent}")
+    # indent <> title <> str <> "\n"
+    indent("#{title} #{str}", 10, true) <> "\n"
+  end
+
+  defp indent(str, level, commented?)
+  defp indent(str, level, false) do
+    String.duplicate(" ", level)
+    |> do_indent(str)
+  end
+  defp indent(str, level, true) when level > 2 do
+    (String.duplicate(" ", level - 2) <> "# ")
+    |> do_indent(str)
+  end
+  defp indent(str, _level, true),
+    do: do_indent("# ", str)
+
+  defp indent(str, level, cmt) when is_binary(cmt) and level > length(cmt) do
+    (String.duplicate(" ", level - length(cmt)) <> cmt)
+    |> do_indent(str)
+  end
+  defp indent(str, _level, cmt) when is_binary(cmt),
+    do: do_indent(cmt, str)
+
+  defp do_indent(indent, str) do
+    str
+    |> String.split("\n")
+    |> Enum.map(& "#{indent}#{&1}")
+    |> Enum.join("\n")
+  end
+
+  def pretty_cmds_name(cmds, opts) do
+    Enum.map(cmds, &pretty_cmd_name(&1, opts))
+  end
+  def pretty_cmd_name({:set, {:var, n}, {:call, mod, fun, args}}, opts) do
+    args =
+      args
+      |> Enum.with_index()
+      |> Enum.map(fn
+        {{:var, m}, _} -> "var#{m}"
+        {arg, i} -> case Keyword.get(opts, :cmd_args, true) do
+               true -> inspectx(arg, opts)
+               false -> "arg#{n}_#{i+1}"
+             end
+      end)
+      |> Enum.join(", ")
+    "var#{n} = #{inspect mod}.#{fun}(#{args})"
+  end
+
+  def inspectx({:exception, :error, exception, stacktrace}, _opts) do
+    Exception.format :error, exception, stacktrace
+  end
+  def inspectx(x, opts) do
+    opts = Keyword.get(opts, :inspect_opts, [])
+    default_opts = [
+      pretty: true,
+      limit: :infinity,
+      syntax_colors: syntax_colors()
+    ]
+    inspect x, Keyword.merge(default_opts, opts)
+  end
+
+  defp syntax_colors do
+    IEx.Config.color :syntax_colors
+  end
+end

--- a/test/statem_pretty_reports_test.exs
+++ b/test/statem_pretty_reports_test.exs
@@ -1,0 +1,726 @@
+defmodule PropCheck.Test.PrettyReports do
+  use PropCheck
+  use PropCheck.StateM
+  use ExUnit.Case
+
+  require Logger
+
+  import ExUnit.CaptureIO
+
+  describe "print out on command crash" do
+    # Command crashed.
+    #
+    # Commands:
+    #    var1 = PropCheck.Test.PrettyReports.noop(0)
+    #         # -> :ok
+    #         # Post state: [0]
+    #
+    #    var2 = PropCheck.Test.PrettyReports.noop(1)
+    #         # -> :ok
+    #         # Post state: [1, 0]
+    #
+    #    var3 = PropCheck.Test.PrettyReports.noop(2)
+    #         # -> :ok
+    #         # Post state: [2, 1, 0]
+    #
+    #    var4 = PropCheck.Test.PrettyReports.noop(3)
+    #         # -> :ok
+    #         # Post state: [3, 2, 1, 0]
+    #
+    # #! var5 = PropCheck.Test.PrettyReports.crash_command()
+    #         # -> ** (RuntimeError) Crash
+    #         #     test/statem_pretty_reports_test.exs:99: PropCheck.Test.PrettyReports.crash_command/0
+    #         #     (proper) src/proper_statem.erl:581: :proper_statem.safe_apply/3
+    #         #     (proper) src/proper_statem.erl:537: :proper_statem.run_commands/5
+    #         #     (proper) src/proper_statem.erl:506: :proper_statem.run_commands/3
+    #         #     test/statem_pretty_reports_test.exs:67: anonymous fn/0 in PropCheck.Test.PrettyReports."test command crash "/1
+    #         #     (ex_unit) lib/ex_unit/capture_io.ex:151: ExUnit.CaptureIO.do_capture_io/2
+    #         #     (ex_unit) lib/ex_unit/capture_io.ex:121: ExUnit.CaptureIO.do_capture_io/3
+    #         #     test/statem_pretty_reports_test.exs:65: PropCheck.Test.PrettyReports."test command crash "/1
+    #         #     (ex_unit) lib/ex_unit/runner.ex:355: ExUnit.Runner.exec_test/1
+    #         #     (stdlib) timer.erl:166: :timer.tc/1
+    #         #     (ex_unit) lib/ex_unit/runner.ex:306: anonymous fn/4 in ExUnit.Runner.spawn_test_monitor/4
+    #         #
+    #
+    #
+    # Last state:
+    # [3, 2, 1, 0]
+
+    setup do
+      cmds = command_crash_seq()
+
+      log = strip_ansi_sequences capture_io(fn ->
+        __MODULE__
+        |> run_commands(cmds)
+        |> print_report(cmds)
+      end)
+
+      lines = String.split(log, "\n")
+
+      [log: log, lines: lines]
+    end
+
+    test "has correct title", c do
+      assert c.log =~ "Command crashed."
+    end
+
+    test "has listed commands only up to the crash ", c do
+      commands_num =
+        c.lines
+        |> Enum.filter(& Regex.match?(~r/var\d+ = /, &1))
+        |> Enum.count()
+
+      assert commands_num == 5
+    end
+
+    test "last command is the failing one", c do
+      last_cmd =
+        c.lines
+        |> Enum.filter(& Regex.match?(~r/var\d+ = /, &1))
+        |> List.last()
+
+      assert last_cmd =~ "#! var"
+    end
+
+    test "failing command returns exception", c do
+      last_cmd_idx = Enum.find_index(c.lines, & &1 =~ ~r/^#! var\d+ = /m)
+
+      assert Enum.at(c.lines, last_cmd_idx + 1) =~ "# -> ** (RuntimeError) Crash"
+    end
+
+    test "commands' return values are printed out by default", c do
+      cmd_idxs =
+        c.lines
+        |> Enum.with_index()
+        |> Enum.filter(fn {line, _i} -> line =~ ~r/^var\d+ = /m end)
+
+      for {_line, i} <- cmd_idxs,
+        do: assert Enum.at(c.lines, i + 1) =~ "# -> "
+    end
+
+    test "post command states are printed out by default", c do
+      cmd_idxs =
+        c.lines
+        |> Enum.with_index()
+        |> Enum.filter(fn {line, _i} -> line =~ ~r/^var\d+ = /m end)
+        |> Enum.with_index()
+        |> Enum.map(fn {{line, line_idx}, cmd_idx} -> {line, line_idx, cmd_idx} end)
+
+      for {_line, line_idx, cmd_idx} <- cmd_idxs do
+        state = cmd_idx..0 |> inspect
+        assert Enum.at(c.lines, line_idx + 2) =~ "# Post state: #{state}"
+      end
+    end
+
+    test "correct last state is printed out", c do
+      assert c.log =~ """
+      Last state:
+      [3, 2, 1, 0]
+      """
+    end
+  end
+
+  describe "print out on precondition crash (on execution phase)" do
+    # Precondition crashed:
+    # ** (RuntimeError) Crash
+    #     test/statem_pretty_reports_test.exs:269: PropCheck.Test.PrettyReports.precondition/2
+    #     (proper) src/proper_statem.erl:563: :proper_statem.check_precondition/3
+    #     (proper) src/proper_statem.erl:535: :proper_statem.run_commands/5
+    #     (proper) src/proper_statem.erl:506: :proper_statem.run_commands/3
+    #     test/statem_pretty_reports_test.exs:180: anonymous fn/1 in PropCheck.Test.PrettyReports.__ex_unit_setup_1/1
+    #     (ex_unit) lib/ex_unit/capture_io.ex:151: ExUnit.CaptureIO.do_capture_io/2
+    #     (ex_unit) lib/ex_unit/capture_io.ex:121: ExUnit.CaptureIO.do_capture_io/3
+    #     test/statem_pretty_reports_test.exs:178: PropCheck.Test.PrettyReports.__ex_unit_setup_1/1
+    #     test/statem_pretty_reports_test.exs:1: PropCheck.Test.PrettyReports.__ex_unit__/2
+    #     (ex_unit) lib/ex_unit/runner.ex:348: ExUnit.Runner.exec_test_setup/2
+    #     (ex_unit) lib/ex_unit/runner.ex:307: anonymous fn/2 in ExUnit.Runner.spawn_test_monitor/4
+    #     (stdlib) timer.erl:166: :timer.tc/1
+    #     (ex_unit) lib/ex_unit/runner.ex:306: anonymous fn/4 in ExUnit.Runner.spawn_test_monitor/4
+    #
+    #
+    # Commands:
+    #    var1 = PropCheck.Test.PrettyReports.noop(0)
+    #         # -> :ok
+    #         # Post state: [0]
+    #
+    #    var2 = PropCheck.Test.PrettyReports.noop(1)
+    #         # -> :ok
+    #         # Post state: [1, 0]
+    #
+    #    var3 = PropCheck.Test.PrettyReports.noop(2)
+    #         # -> :ok
+    #         # Post state: [2, 1, 0]
+    #
+    #    var4 = PropCheck.Test.PrettyReports.noop(3)
+    #         # -> :ok
+    #
+    # #! var5 = PropCheck.Test.PrettyReports.crash_precond()
+    #
+    #
+    # Last state:
+    # [3, 2, 1, 0]
+
+    setup do
+      cmds = precond_crash_seq()
+
+      log = strip_ansi_sequences capture_io(fn ->
+        __MODULE__
+        |> run_commands(cmds)
+        |> print_report(cmds)
+      end)
+
+      lines = String.split(log, "\n")
+
+      [log: log, lines: lines]
+    end
+
+    test "has correct title", c do
+      assert c.log =~ "Precondition crashed:"
+    end
+
+    test "has listed commands only up to the crash ", c do
+      commands_num =
+        c.lines
+        |> Enum.filter(& Regex.match?(~r/var\d+ = /, &1))
+        |> Enum.count()
+
+      assert commands_num == 5
+    end
+
+    test "last command is the failing one", c do
+      last_cmd =
+        c.lines
+        |> Enum.filter(& Regex.match?(~r/var\d+ = /, &1))
+        |> List.last()
+
+      assert last_cmd =~ "#! var"
+    end
+
+    test "exception printed out after header", c do
+      header_idx = 2
+      assert Enum.at(c.lines, header_idx + 1) =~ ~r/^\*\* \(RuntimeError\) Crash$/
+    end
+
+    test "commands' return values are printed out by default", c do
+      cmd_idxs =
+        c.lines
+        |> Enum.with_index()
+        |> Enum.filter(fn {line, _i} -> line =~ ~r/^var\d+ = /m end)
+
+      for {_line, i} <- cmd_idxs,
+        do: assert Enum.at(c.lines, i + 1) =~ "# -> "
+    end
+
+    test "post command states are printed out by default", c do
+      cmd_idxs =
+        c.lines
+        |> Enum.with_index()
+        |> Enum.filter(fn {line, _i} -> line =~ ~r/^var\d+ = /m end)
+        |> Enum.with_index()
+        |> Enum.map(fn {{line, line_idx}, cmd_idx} -> {line, line_idx, cmd_idx} end)
+
+      for {_line, line_idx, cmd_idx} <- cmd_idxs do
+        state = cmd_idx..0 |> inspect
+        assert Enum.at(c.lines, line_idx + 2) =~ "# Post state: #{state}"
+      end
+    end
+
+    test "correct last state is printed out", c do
+      assert c.log =~ """
+      Last state:
+      [3, 2, 1, 0]
+      """
+    end
+  end
+
+  describe "print out on precondition fail (on execution phase)" do
+    # Precondition failed.
+    #
+    # Commands:
+    #    var1 = PropCheck.Test.PrettyReports.noop(0)
+    #         # -> :ok
+    #         # Post state: [0]
+    #
+    #    var2 = PropCheck.Test.PrettyReports.noop(1)
+    #         # -> :ok
+    #         # Post state: [1, 0]
+    #
+    #    var3 = PropCheck.Test.PrettyReports.noop(2)
+    #         # -> :ok
+    #         # Post state: [2, 1, 0]
+    #
+    #    var4 = PropCheck.Test.PrettyReports.noop(3)
+    #         # -> :ok
+    #
+    # #! var5 = PropCheck.Test.PrettyReports.fail_precond()
+    #
+    #
+    # Last state:
+    # [3, 2, 1, 0]
+
+    setup do
+      cmds = precond_fail_seq()
+
+      log = strip_ansi_sequences capture_io(fn ->
+        __MODULE__
+        |> run_commands(cmds)
+        |> print_report(cmds)
+      end)
+
+      lines = String.split(log, "\n")
+
+      [log: log, lines: lines]
+    end
+
+    test "has correct title", c do
+      assert c.log =~ "Precondition failed."
+    end
+
+    test "has listed commands only up to the crash ", c do
+      commands_num =
+        c.lines
+        |> Enum.filter(& Regex.match?(~r/var\d+ = /, &1))
+        |> Enum.count()
+
+      assert commands_num == 5
+    end
+
+    test "last command is the failing one", c do
+      last_cmd =
+        c.lines
+        |> Enum.filter(& Regex.match?(~r/var\d+ = /, &1))
+        |> List.last()
+
+      assert last_cmd =~ "#! var"
+    end
+
+    test "no return value printed on failing command", c do
+      last_cmd_idx = Enum.find_index(c.lines, & &1 =~ ~r/^#! var\d+ = /m)
+
+      assert Enum.at(c.lines, last_cmd_idx + 1) == ""
+    end
+
+    test "commands' return values are printed out by default", c do
+      cmd_idxs =
+        c.lines
+        |> Enum.with_index()
+        |> Enum.filter(fn {line, _i} -> line =~ ~r/^var\d+ = /m end)
+
+      for {_line, i} <- cmd_idxs,
+        do: assert Enum.at(c.lines, i + 1) =~ "# -> "
+    end
+
+    test "post command states are printed out by default", c do
+      cmd_idxs =
+        c.lines
+        |> Enum.with_index()
+        |> Enum.filter(fn {line, _i} -> line =~ ~r/^var\d+ = /m end)
+        |> Enum.with_index()
+        |> Enum.map(fn {{line, line_idx}, cmd_idx} -> {line, line_idx, cmd_idx} end)
+
+      for {_line, line_idx, cmd_idx} <- cmd_idxs do
+        state = cmd_idx..0 |> inspect
+        assert Enum.at(c.lines, line_idx + 2) =~ "# Post state: #{state}"
+      end
+    end
+
+    test "correct last state is printed out", c do
+      assert c.log =~ """
+      Last state:
+      [3, 2, 1, 0]
+      """
+    end
+  end
+
+  describe "print out on postcondition crash (on execution phase)" do
+    # Postcondition crashed:
+    # ** (RuntimeError) Crash
+    #     test/statem_pretty_reports_test.exs:392: PropCheck.Test.PrettyReports.postcondition/3
+    #     (proper) src/proper_statem.erl:572: :proper_statem.check_postcondition/4
+    #     (proper) src/proper_statem.erl:541: :proper_statem.run_commands/5
+    #     (proper) src/proper_statem.erl:506: :proper_statem.run_commands/3
+    #     test/statem_pretty_reports_test.exs:295: anonymous fn/1 in PropCheck.Test.PrettyReports.__ex_unit_setup_2/1
+    #     (ex_unit) lib/ex_unit/capture_io.ex:151: ExUnit.CaptureIO.do_capture_io/2
+    #     (ex_unit) lib/ex_unit/capture_io.ex:121: ExUnit.CaptureIO.do_capture_io/3
+    #     test/statem_pretty_reports_test.exs:293: PropCheck.Test.PrettyReports.__ex_unit_setup_2/1
+    #     test/statem_pretty_reports_test.exs:1: PropCheck.Test.PrettyReports.__ex_unit__/2
+    #     (ex_unit) lib/ex_unit/runner.ex:348: ExUnit.Runner.exec_test_setup/2
+    #     (ex_unit) lib/ex_unit/runner.ex:307: anonymous fn/2 in ExUnit.Runner.spawn_test_monitor/4
+    #     (stdlib) timer.erl:166: :timer.tc/1
+    #     (ex_unit) lib/ex_unit/runner.ex:306: anonymous fn/4 in ExUnit.Runner.spawn_test_monitor/4
+    #
+    #
+    # Commands:
+    #    var1 = PropCheck.Test.PrettyReports.noop(0)
+    #         # -> :ok
+    #         # Post state: [0]
+    #
+    #    var2 = PropCheck.Test.PrettyReports.noop(1)
+    #         # -> :ok
+    #         # Post state: [1, 0]
+    #
+    #    var3 = PropCheck.Test.PrettyReports.noop(2)
+    #         # -> :ok
+    #         # Post state: [2, 1, 0]
+    #
+    #    var4 = PropCheck.Test.PrettyReports.noop(3)
+    #         # -> :ok
+    #         # Post state: [3, 2, 1, 0]
+    #
+    # #! var5 = PropCheck.Test.PrettyReports.crash_postcond()
+    #         # -> :ok
+    #
+    #
+    # Last state:
+    # [3, 2, 1, 0]
+
+    setup do
+      cmds = postcond_crash_seq()
+
+      log = strip_ansi_sequences capture_io(fn ->
+        __MODULE__
+        |> run_commands(cmds)
+        |> print_report(cmds)
+      end)
+
+      lines = String.split(log, "\n")
+
+      [log: log, lines: lines]
+    end
+
+    test "has correct title", c do
+      assert c.log =~ "Postcondition crashed:"
+    end
+
+    test "has listed commands only up to the crash ", c do
+      commands_num =
+        c.lines
+        |> Enum.filter(& Regex.match?(~r/var\d+ = /, &1))
+        |> Enum.count()
+
+      assert commands_num == 5
+    end
+
+    test "last command is the failing one", c do
+      last_cmd =
+        c.lines
+        |> Enum.filter(& Regex.match?(~r/var\d+ = /, &1))
+        |> List.last()
+
+      assert last_cmd =~ "#! var"
+    end
+
+    test "exception printed out after header", c do
+      header_idx = 2
+      assert Enum.at(c.lines, header_idx + 1) =~ ~r/^\*\* \(RuntimeError\) Crash$/
+    end
+
+    test "commands' return values are printed out by default", c do
+      cmd_idxs =
+        c.lines
+        |> Enum.with_index()
+        |> Enum.filter(fn {line, _i} -> line =~ ~r/^var\d+ = /m end)
+
+      for {_line, i} <- cmd_idxs,
+        do: assert Enum.at(c.lines, i + 1) =~ "# -> "
+    end
+
+    test "post command states are printed out by default", c do
+      cmd_idxs =
+        c.lines
+        |> Enum.with_index()
+        |> Enum.filter(fn {line, _i} -> line =~ ~r/^var\d+ = /m end)
+        |> Enum.with_index()
+        |> Enum.map(fn {{line, line_idx}, cmd_idx} -> {line, line_idx, cmd_idx} end)
+
+      for {_line, line_idx, cmd_idx} <- cmd_idxs do
+        state = cmd_idx..0 |> inspect
+        assert Enum.at(c.lines, line_idx + 2) =~ "# Post state: #{state}"
+      end
+    end
+
+    test "correct last state is printed out", c do
+      assert c.log =~ """
+      Last state:
+      [3, 2, 1, 0]
+      """
+    end
+  end
+
+  describe "print out on postcondition fail (on execution phase)" do
+    # Postcondition failed.
+    #
+    # Commands:
+    #    var1 = PropCheck.Test.PrettyReports.noop(0)
+    #         # -> :ok
+    #         # Post state: [0]
+    #
+    #    var2 = PropCheck.Test.PrettyReports.noop(1)
+    #         # -> :ok
+    #         # Post state: [1, 0]
+    #
+    #    var3 = PropCheck.Test.PrettyReports.noop(2)
+    #         # -> :ok
+    #         # Post state: [2, 1, 0]
+    #
+    #    var4 = PropCheck.Test.PrettyReports.noop(3)
+    #         # -> :ok
+    #         # Post state: [3, 2, 1, 0]
+    #
+    # #! var5 = PropCheck.Test.PrettyReports.fail_postcond()
+    #         # -> :ok
+    #
+    #
+    # Last state:
+    # [3, 2, 1, 0]
+
+    setup do
+      cmds = postcond_fail_seq()
+
+      log = strip_ansi_sequences capture_io(fn ->
+        __MODULE__
+        |> run_commands(cmds)
+        |> print_report(cmds)
+      end)
+
+      lines = String.split(log, "\n")
+
+      [log: log, lines: lines]
+    end
+
+    test "has correct title", c do
+      assert c.log =~ "Postcondition failed."
+    end
+
+    test "has listed commands only up to the crash ", c do
+      commands_num =
+        c.lines
+        |> Enum.filter(& Regex.match?(~r/var\d+ = /, &1))
+        |> Enum.count()
+
+      assert commands_num == 5
+    end
+
+    test "last command is the failing one", c do
+      last_cmd =
+        c.lines
+        |> Enum.filter(& Regex.match?(~r/var\d+ = /, &1))
+        |> List.last()
+
+      assert last_cmd =~ "#! var"
+    end
+
+    test "return value printed on failing command", c do
+      last_cmd_idx = Enum.find_index(c.lines, & &1 =~ ~r/^#! var\d+ = /m)
+
+      assert Enum.at(c.lines, last_cmd_idx + 1) =~ "# -> :ok"
+    end
+
+    test "commands' return values are printed out by default", c do
+      cmd_idxs =
+        c.lines
+        |> Enum.with_index()
+        |> Enum.filter(fn {line, _i} -> line =~ ~r/^var\d+ = /m end)
+
+      for {_line, i} <- cmd_idxs,
+        do: assert Enum.at(c.lines, i + 1) =~ "# -> "
+    end
+
+    test "post command states are printed out by default", c do
+      cmd_idxs =
+        c.lines
+        |> Enum.with_index()
+        |> Enum.filter(fn {line, _i} -> line =~ ~r/^var\d+ = /m end)
+        |> Enum.with_index()
+        |> Enum.map(fn {{line, line_idx}, cmd_idx} -> {line, line_idx, cmd_idx} end)
+
+      for {_line, line_idx, cmd_idx} <- cmd_idxs do
+        state = cmd_idx..0 |> inspect
+        assert Enum.at(c.lines, line_idx + 2) =~ "# Post state: #{state}"
+      end
+    end
+
+    test "correct last state is printed out", c do
+      assert c.log =~ """
+      Last state:
+      [3, 2, 1, 0]
+      """
+    end
+  end
+
+  describe "printout options," do
+    defp run(opts) do
+      cmds = postcond_fail_seq()
+
+      log = strip_ansi_sequences capture_io(fn ->
+        __MODULE__
+        |> run_commands(cmds)
+        |> print_report(cmds, opts)
+      end)
+
+      lines = String.split(log, "\n")
+
+      %{log: log, lines: lines}
+    end
+
+    test "last state can be suppressed" do
+      c = run [last_state: false]
+      refute c.log =~ "Last state:"
+    end
+
+    test "post state is enabled by default" do
+      c = run []
+      assert c.log =~ "# Post state:"
+    end
+
+    test "post state can be suppressed" do
+      c = run [post_cmd_state: false]
+      refute c.log =~ "# Post state:"
+    end
+
+    test "pre state is disabled by default" do
+      c = run []
+      refute c.log =~ "# pre state:"
+    end
+
+    test "pre state can be enabled" do
+      c = run [pre_cmd_state: true]
+      assert c.log =~ "# Pre state:"
+    end
+
+    test "command arguments as literals is enabled by default" do
+      c = run []
+      assert c.log =~ "var1 = PropCheck.Test.PrettyReports.noop(0)"
+      assert c.log =~ "var2 = PropCheck.Test.PrettyReports.noop(1)"
+      assert c.log =~ "var3 = PropCheck.Test.PrettyReports.noop(2)"
+    end
+
+    test "command arguments as literals can be suppressed" do
+      c = run [cmd_args: false]
+      assert c.log =~ "var1 = PropCheck.Test.PrettyReports.noop(arg1_1)"
+      assert c.log =~ "var2 = PropCheck.Test.PrettyReports.noop(arg2_1)"
+      assert c.log =~ "var3 = PropCheck.Test.PrettyReports.noop(arg3_1)"
+    end
+  end
+
+  #
+  #
+  # StateM implementation
+  #
+
+  def initial_state, do: []
+
+  def command(_state) do
+    oneof [
+      {:call, __MODULE__, :noop, [any()]},
+      {:call, __MODULE__, :crash_precond, []},
+      {:call, __MODULE__, :fail_precond, []},
+      {:call, __MODULE__, :crash_postcond, []},
+      {:call, __MODULE__, :fail_postcond, []},
+      {:call, __MODULE__, :crash_command, []},
+    ]
+  end
+
+  def precondition(state, {:call, _, :crash_precond, _}) do
+    if not Keyword.keyword?(state) do
+      raise "Crash"
+    end
+  end
+  def precondition(state, {:call, _, :fail_precond, _}) do
+    if not Keyword.keyword?(state) do
+      false
+    end
+  end
+  def precondition(_state, _), do: true
+
+  def postcondition(_state, {:call, _, :crash_postcond, _}, _result) do
+    raise "Crash"
+  end
+  def postcondition(_state, {:call, _, :fail_postcond, _}, _result) do
+    false
+  end
+  def postcondition(_state, _, _result) do
+    true
+  end
+
+  def next_state(state, _, {:call, _, :noop, _}) do
+    [length(state) | state]
+  end
+  def next_state(state, _, _) do
+    state
+  end
+
+  def noop(_) do
+    :ok
+  end
+
+  def crash_command do
+    raise "Crash"
+  end
+
+  def fail_precond, do: :ok
+  def crash_precond, do: :ok
+
+  def fail_postcond, do: :ok
+  def crash_postcond, do: :ok
+
+  #
+  #
+  # Helpers
+  #
+
+  defp command_crash_seq, do: [
+    {:set, {:var, 1}, {:call, __MODULE__, :noop, [0]}},
+    {:set, {:var, 2}, {:call, __MODULE__, :noop, [1]}},
+    {:set, {:var, 3}, {:call, __MODULE__, :noop, [2]}},
+    {:set, {:var, 4}, {:call, __MODULE__, :noop, [3]}},
+    {:set, {:var, 5}, {:call, __MODULE__, :crash_command, []}},
+    {:set, {:var, 6}, {:call, __MODULE__, :noop, [4]}},
+    {:set, {:var, 7}, {:call, __MODULE__, :noop, [5]}},
+  ]
+
+  defp precond_crash_seq, do: [
+    {:set, {:var, 1}, {:call, __MODULE__, :noop, [0]}},
+    {:set, {:var, 2}, {:call, __MODULE__, :noop, [1]}},
+    {:set, {:var, 3}, {:call, __MODULE__, :noop, [2]}},
+    {:set, {:var, 4}, {:call, __MODULE__, :noop, [3]}},
+    {:set, {:var, 5}, {:call, __MODULE__, :crash_precond, []}},
+    {:set, {:var, 6}, {:call, __MODULE__, :noop, [4]}},
+    {:set, {:var, 7}, {:call, __MODULE__, :noop, [5]}},
+  ]
+
+  defp precond_fail_seq, do: [
+    {:set, {:var, 1}, {:call, __MODULE__, :noop, [0]}},
+    {:set, {:var, 2}, {:call, __MODULE__, :noop, [1]}},
+    {:set, {:var, 3}, {:call, __MODULE__, :noop, [2]}},
+    {:set, {:var, 4}, {:call, __MODULE__, :noop, [3]}},
+    {:set, {:var, 5}, {:call, __MODULE__, :fail_precond, []}},
+    {:set, {:var, 6}, {:call, __MODULE__, :noop, [4]}},
+    {:set, {:var, 7}, {:call, __MODULE__, :noop, [5]}},
+  ]
+
+  defp postcond_crash_seq, do: [
+    {:set, {:var, 1}, {:call, __MODULE__, :noop, [0]}},
+    {:set, {:var, 2}, {:call, __MODULE__, :noop, [1]}},
+    {:set, {:var, 3}, {:call, __MODULE__, :noop, [2]}},
+    {:set, {:var, 4}, {:call, __MODULE__, :noop, [3]}},
+    {:set, {:var, 5}, {:call, __MODULE__, :crash_postcond, []}},
+    {:set, {:var, 6}, {:call, __MODULE__, :noop, [4]}},
+    {:set, {:var, 7}, {:call, __MODULE__, :noop, [5]}},
+  ]
+
+  defp postcond_fail_seq, do: [
+    {:set, {:var, 1}, {:call, __MODULE__, :noop, [0]}},
+    {:set, {:var, 2}, {:call, __MODULE__, :noop, [1]}},
+    {:set, {:var, 3}, {:call, __MODULE__, :noop, [2]}},
+    {:set, {:var, 4}, {:call, __MODULE__, :noop, [3]}},
+    {:set, {:var, 5}, {:call, __MODULE__, :fail_postcond, []}},
+    {:set, {:var, 6}, {:call, __MODULE__, :noop, [4]}},
+    {:set, {:var, 7}, {:call, __MODULE__, :noop, [5]}},
+  ]
+
+  defp strip_ansi_sequences(str) do
+    r = ~r/\e\[.*?m/
+    Regex.replace(r, str, "")
+  end
+end


### PR DESCRIPTION
Conventional way of inspecting the counterexamples generated by stateful
properties involves inspecting the history of commands' return values,
model's state changes and inspecting the property result itself (see
`test/movie_test.exs`). This is not only ugly & hard to read, but also
can be misleading, because depending of the reason of failure the
failing command can be either the last command with the associated
history, or the one before that.

This commit adds a report generator, that prints out a user-friendly and
IEx-shell-friendly (can be safely pasted into the IEx shell) list of
commands, correctly indicating which command was at fault and what kind
of failure was it. Also printing out associated return values and
model's state at each transition.


Compare [inspecting  `&run_commands/2` result](http://sixteencolors.net/paste/x1/c254a987.ans.png) to [new report generator](http://sixteencolors.net/paste/x1/aeb14869.ans.png) -  I've 
introduced 2 bugs: when there are more than 3 users created, asking for
popcorn results in `:no_more_left` and when that happens postcondition
raises an error.