### PR TITLE
Do not crash property if no counter example was returned

### DIFF
--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -164,23 +164,31 @@ defmodule PropCheck.Properties do
 
     proper_opts = PropCheck.Utils.to_proper_opts(opts)
 
-    case CounterStrike.counter_example(name) do
-      :none -> PropCheck.quickcheck(p, [:long_result] ++ proper_opts)
-      :others ->
-        # since the tag is set, we execute everything. You can limit
-        # the amount of checks by using either --stale or --only failing_prop
-        qc(p, proper_opts)
-      {:ok, counter_example} ->
-        # Logger.debug "Found counter example #{inspect counter_example}"
-        result = PropCheck.check(p, counter_example, [:long_result] ++ proper_opts)
-        with true <- result do
+    result =
+      case CounterStrike.counter_example(name) do
+        :none -> PropCheck.quickcheck(p, [:long_result] ++ proper_opts)
+        :others ->
+          # since the tag is set, we execute everything. You can limit
+          # the amount of checks by using either --stale or --only failing_prop
           qc(p, proper_opts)
-        else
-          false -> {:rerun_failed, counter_example}
-          e = {:error, _} -> e
-        end
-    end
-    |> handle_check_results(name, opts, should_fail, store_counter_example?)
+        {:ok, counter_example} ->
+          # Logger.debug "Found counter example #{inspect counter_example}"
+          result = PropCheck.check(p, counter_example, [:long_result] ++ proper_opts)
+          with true <- result do
+            qc(p, proper_opts)
+          else
+            false -> {:rerun_failed, counter_example}
+            e = {:error, _} -> e
+          end
+      end
+
+    handle_check_results(%{
+      result: result,
+      name: name,
+      opts: opts,
+      should_fail: should_fail,
+      store_counter_example?: store_counter_example?
+    })
   end
 
   defp qc(p, opts), do: PropCheck.quickcheck(p, [:long_result] ++ opts)
@@ -188,44 +196,31 @@ defmodule PropCheck.Properties do
   # Handles the result of executing quick check or a re-check of a counter example.
   # In this method a new found counter example is added to `CounterStrike`. Note that
   # some macros such as exists/2 do not return counter examples when they fail.
-  defp handle_check_results(true, _name, _opts, _should_fail = false, _store_counter_example?) do
+  defp handle_check_results(%{result: true, should_fail: false}) do
     true
   end
 
-  defp handle_check_results(true, name, _opts, _should_fail = true, _store_counter_example?) do
+  defp handle_check_results(args = %{result: true, should_fail: true}) do
     raise ExUnit.AssertionError,
-      message: "Property #{mfa_to_string(name)} should fail, but succeeded for all test data :-(",
+      message: "Property #{mfa_to_string(args.name)} should fail, but succeeded for all test data :-(",
       expr: nil
   end
 
-  defp handle_check_results(
-         error = {:error, _},
-         name,
-         _opts,
-         _should_fail,
-         _store_counter_example?
-       ) do
+  defp handle_check_results(args = %{result: error = {:error, _}}) do
     raise ExUnit.AssertionError,
-      message: "Property #{mfa_to_string(name)} failed with an error: #{inspect(error)}",
+      message: "Property #{mfa_to_string(args.name)} failed with an error: #{inspect(error)}",
       expr: nil
   end
 
-  defp handle_check_results(
-         counter_example,
-         _name,
-         _opts,
-         _should_fail = true,
-         _store_counter_example?
-       )
+  defp handle_check_results(%{result: counter_example, should_fail: true})
        when is_list(counter_example) do
     true
   end
 
-  defp handle_check_results(counter_example, name, opts, _should_fail, store_counter_example?)
-       when is_list(counter_example) do
+  defp handle_check_results(args = %{result: counter_example}) when is_list(counter_example) do
     counter_example_message =
-      if store_counter_example? do
-        CounterStrike.add_counter_example(name, counter_example)
+      if args.store_counter_example? do
+        CounterStrike.add_counter_example(args.name, counter_example)
         "Counter example stored."
       else
         "Counter example NOT stored, :store_counter_example is set to false."
@@ -234,43 +229,36 @@ defmodule PropCheck.Properties do
     raise ExUnit.AssertionError,
       message:
         """
-        Property #{mfa_to_string(name)} failed. Counter-Example is:
+        Property #{mfa_to_string(args.name)} failed. Counter-Example is:
         #{inspect(counter_example, pretty: true)}
 
         #{counter_example_message}
         """
-        |> add_additional_output(opts),
+        |> add_additional_output(args.opts),
       expr: nil
   end
 
-  defp handle_check_results(
-         {:rerun_failed, counter_example},
-         name,
-         opts,
-         _should_fail,
-         _store_counter_example?
-       )
-       when is_list(counter_example) do
-    CounterStrike.add_counter_example(name, counter_example)
+  defp handle_check_results(args = %{result: {:rerun_failed, counter_example}}) when is_list(counter_example) do
+    CounterStrike.add_counter_example(args.name, counter_example)
 
     raise ExUnit.AssertionError,
       message:
         """
-        Property #{mfa_to_string(name)} failed. Counter-Example is:
+        Property #{mfa_to_string(args.name)} failed. Counter-Example is:
         #{inspect(counter_example, pretty: true)}
 
         Consider running `MIX_ENV=test mix propcheck.clean` if a bug in a generator was
         identified and fixed. PropCheck cannot identify changes to generators. See
         https://github.com/alfert/propcheck/issues/30 for more details.
         """
-        |> add_additional_output(opts),
+        |> add_additional_output(args.opts),
       expr: nil
   end
 
-  defp handle_check_results(_results, name, _opts, _should_fail, _store_counter_example?) do
+  defp handle_check_results(args) do
     raise ExUnit.AssertionError,
       message: """
-      Property #{mfa_to_string(name)} failed. There is no counter-example available.
+      Property #{mfa_to_string(args.name)} failed. There is no counter-example available.
       """
   end
 

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -188,57 +188,90 @@ defmodule PropCheck.Properties do
   # Handles the result of executing quick check or a re-check of a counter example.
   # In this method a new found counter example is added to `CounterStrike`. Note that
   # some macros such as exists/2 do not return counter examples when they fail.
-  defp handle_check_results(results, name, opts, should_fail, store_counter_example?) do
-    case results do
-      error = {:error, _} ->
-        raise ExUnit.AssertionError, [
-          message:
-            "Property #{mfa_to_string name} failed with an error: #{inspect(error)}",
-          expr: nil
-        ]
-      true when not should_fail -> true
-      true when should_fail ->
-        raise ExUnit.AssertionError, [
-          message:
-            "Property #{mfa_to_string name} should fail, but succeeded for all test data :-(",
-          expr: nil]
-      counter_example when is_list(counter_example) and should_fail -> true
-      counter_example when is_list(counter_example) ->
-        counter_example_message =
-          if store_counter_example? do
-            CounterStrike.add_counter_example(name, counter_example)
-            "Counter example stored."
-          else
-            "Counter example NOT stored, :store_counter_example is set to false."
-          end
+  defp handle_check_results(true, _name, _opts, _should_fail = false, _store_counter_example?) do
+    true
+  end
 
-        raise ExUnit.AssertionError, [
-          message: """
-          Property #{mfa_to_string name} failed. Counter-Example is:
-          #{inspect counter_example, pretty: true}
+  defp handle_check_results(true, name, _opts, _should_fail = true, _store_counter_example?) do
+    raise ExUnit.AssertionError,
+      message: "Property #{mfa_to_string(name)} should fail, but succeeded for all test data :-(",
+      expr: nil
+  end
 
-          #{counter_example_message}
-          """ |> add_additional_output(opts),
-          expr: nil]
-      {:rerun_failed, counter_example} when is_list(counter_example) ->
+  defp handle_check_results(
+         error = {:error, _},
+         name,
+         _opts,
+         _should_fail,
+         _store_counter_example?
+       ) do
+    raise ExUnit.AssertionError,
+      message: "Property #{mfa_to_string(name)} failed with an error: #{inspect(error)}",
+      expr: nil
+  end
+
+  defp handle_check_results(
+         counter_example,
+         _name,
+         _opts,
+         _should_fail = true,
+         _store_counter_example?
+       )
+       when is_list(counter_example) do
+    true
+  end
+
+  defp handle_check_results(counter_example, name, opts, _should_fail, store_counter_example?)
+       when is_list(counter_example) do
+    counter_example_message =
+      if store_counter_example? do
         CounterStrike.add_counter_example(name, counter_example)
-        raise ExUnit.AssertionError, [
-          message: """
-          Property #{mfa_to_string name} failed. Counter-Example is:
-          #{inspect counter_example, pretty: true}
+        "Counter example stored."
+      else
+        "Counter example NOT stored, :store_counter_example is set to false."
+      end
 
-          Consider running `MIX_ENV=test mix propcheck.clean` if a bug in a generator was
-          identified and fixed. PropCheck cannot identify changes to generators. See
-          https://github.com/alfert/propcheck/issues/30 for more details.
-          """ |> add_additional_output(opts),
-          expr: nil]
-      _ ->
-        raise ExUnit.AssertionError, [
-          message: """
-          Property #{mfa_to_string name} failed. There is no counter-example available.
-          """
-        ]
-    end
+    raise ExUnit.AssertionError,
+      message:
+        """
+        Property #{mfa_to_string(name)} failed. Counter-Example is:
+        #{inspect(counter_example, pretty: true)}
+
+        #{counter_example_message}
+        """
+        |> add_additional_output(opts),
+      expr: nil
+  end
+
+  defp handle_check_results(
+         {:rerun_failed, counter_example},
+         name,
+         opts,
+         _should_fail,
+         _store_counter_example?
+       )
+       when is_list(counter_example) do
+    CounterStrike.add_counter_example(name, counter_example)
+
+    raise ExUnit.AssertionError,
+      message:
+        """
+        Property #{mfa_to_string(name)} failed. Counter-Example is:
+        #{inspect(counter_example, pretty: true)}
+
+        Consider running `MIX_ENV=test mix propcheck.clean` if a bug in a generator was
+        identified and fixed. PropCheck cannot identify changes to generators. See
+        https://github.com/alfert/propcheck/issues/30 for more details.
+        """
+        |> add_additional_output(opts),
+      expr: nil
+  end
+
+  defp handle_check_results(_results, name, _opts, _should_fail, _store_counter_example?) do
+    raise ExUnit.AssertionError,
+      message: """
+      Property #{mfa_to_string(name)} failed. There is no counter-example available.
+      """
   end
 
   # Add additional output to a message

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -186,7 +186,8 @@ defmodule PropCheck.Properties do
   defp qc(p, opts), do: PropCheck.quickcheck(p, [:long_result] ++ opts)
 
   # Handles the result of executing quick check or a re-check of a counter example.
-  # In this method a new found counter example is added to `CounterStrike`.
+  # In this method a new found counter example is added to `CounterStrike`. Note that
+  # some macros such as exists/2 do not return counter examples when they fail.
   defp handle_check_results(results, name, opts, should_fail, store_counter_example?) do
     case results do
       error = {:error, _} ->
@@ -231,6 +232,12 @@ defmodule PropCheck.Properties do
           https://github.com/alfert/propcheck/issues/30 for more details.
           """ |> add_additional_output(opts),
           expr: nil]
+      _ ->
+        raise ExUnit.AssertionError, [
+          message: """
+          Property #{mfa_to_string name} failed. There is no counter-example available.
+          """
+        ]
     end
   end
 


### PR DESCRIPTION
This fixes the clause error found by @x4lldux when the `exists/2` macro fails.

Fix #133