### PR TITLE
Implement property/1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - mix local.hex --force
   - mix do deps.get, deps.compile, compile --warnings-as-errors
 script:
-  - mix test --cover --trace --exclude will_fail:true --exclude unstable_test:true
+  - mix test --cover --trace --exclude will_fail:true --exclude unstable_test:true --exclude not_implemented:true
   - ./.travis-scripts/verify_storing_counterexamples.sh
   - ./.travis-scripts/verify-verbose.sh
   - ./.travis-scripts/verify-detect-exceptions.sh

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -127,6 +127,7 @@ defmodule PropCheck.Properties do
       end
   end
 
+  @doc false
   def merge_opts(opts, module_default_opts) do
     module_default_opts = case is_function(module_default_opts) do
                             true -> module_default_opts.()

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -286,7 +286,7 @@ defmodule PropCheck.Properties do
   end
 
   @doc """
-  Defines a not implemented property.
+  Defines a not yet implemented property.
 
   This convenient macro provides a property which will always flunk. It resembles
   the `test/1` macro from ExUnit. Similarly to `ExUnit`, it also tags the test with

--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -1,9 +1,9 @@
 defmodule PropCheck.Properties do
-
   @moduledoc """
-  This module defined the `property/4` macro. It is automatically available
+  This module defines the `property/4` and `property/1` macros. It is automatically available
   by `use PropCheck`.
   """
+
   alias PropCheck.CounterStrike
   require Logger
 
@@ -282,5 +282,26 @@ defmodule PropCheck.Properties do
       {_m, beam, _file} = :code.get_object_code(mod)
       {:ok, {_, [{:abstract_code, {_, ac}}]}} = :beam_lib.chunks(beam, [:abstract_code])
       ac |> Enum.map(&:erl_pp.form/1) |> List.flatten |> IO.puts
+  end
+
+  @doc """
+  Defines a not implemented property.
+
+  This convenient macro provides a property which will always flunk. It resembles
+  the `test/1` macro from ExUnit. Similarly to `ExUnit`, it also tags the test with
+  `:not_implemented`, allowing to filter it when running `mix test`.
+
+  ## Example
+
+      property "This property will be implemented in the future"
+
+  """
+  defmacro property(message) do
+    quote bind_quoted: [message: message] do
+      prop_name = ExUnit.Case.register_test(__ENV__, :property, message, [:not_implemented])
+      def unquote(prop_name)(_) do
+        flunk("Not implemented")
+      end
+    end
   end
 end

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -17,4 +17,7 @@ defmodule PropertiesTest do
     assert {:max_size, 1} in opts
     assert {:numtests, 1} in opts
   end
+
+  # This will be filtered with `--exclude not_implemented`.
+  property "not yet implemented"
 end


### PR DESCRIPTION
This implements `property/1` as suggested in #135. Example from `properties_test.exs`:

```
~/tools/propcheck(fix-135 ✗) mix test test/properties_test.exs
Compiling 2 files (.ex)


  1) property not yet implemented (PropertiesTest)
     test/properties_test.exs:22
     Not implemented

.
OK: Passed 1 test(s).
..
OK: Passed 1 test(s).
.

Finished in 0.05 seconds
3 properties, 1 failure

Randomized with seed 546517
[1]    7501 exit 1     mix test test/properties_test.exs
```