### PR TITLE
Refactoring of the Statemachine DSL

### DIFF
--- a/lib/statem_dsl.ex
+++ b/lib/statem_dsl.ex
@@ -427,10 +427,16 @@ defmodule PropCheck.StateM.DSL do
     end
   end
 
+  @deprecated "Use run_commands/2 instead!"
   @doc """
   Runs the list of generated commands according to the model.
 
   Returns the result, the history and the final state of the model.
+
+  Due to an internal refactoring and to achieve a common API with the `PropCheck.StateM`
+  module, we changed the API for `run_commands`. This implementation infers the
+  callback module from the first generated command. Usually, this will be the case,
+  but we cannot rely on that.
   """
   @spec run_commands([command]) :: t
   def run_commands(commands) when length(commands) > 0 do

--- a/test/cache_dsl_test.exs
+++ b/test/cache_dsl_test.exs
@@ -88,7 +88,7 @@ defmodule PropCheck.Test.Cache.DSL do
     assert is_list(cmds)
 
     first = hd(cmds)
-    assert {%__MODULE__{}, {:set, {:var, 1}, {:call, __MODULE__, _, _}}} = first
+    assert {:set, {:var, 1}, {:call, __MODULE__, _, _}} = first
   end
 
   ###########################

--- a/test/cache_dsl_test.exs
+++ b/test/cache_dsl_test.exs
@@ -17,7 +17,7 @@ defmodule PropCheck.Test.Cache.DSL do
     forall cmds <- commands(__MODULE__) do
       # Logger.debug "Commands to run: #{inspect cmds}"
       Cache.start_link(@cache_size)
-      events = run_commands(cmds)
+      events = run_commands(__MODULE__, cmds)
       Cache.stop()
       # Logger.debug "Events are: #{inspect events}"
 
@@ -44,7 +44,7 @@ defmodule PropCheck.Test.Cache.DSL do
       # Cache size is half as big expected, so we will find some cache misses,
       # where the model expects that the value is properly cached.
       Cache.start_link(div(@cache_size, 2))
-      events = run_commands(cmds)
+      events = run_commands(__MODULE__, cmds)
       Cache.stop()
       # Logger.debug "Events are: #{inspect events}"
 

--- a/test/counter_dsl_test.exs
+++ b/test/counter_dsl_test.exs
@@ -31,7 +31,7 @@ defmodule PropCheck.Test.CounterDSL do
     forall cmds <- commands(__MODULE__) do
       trap_exit do
         {:ok, _pid} = Counter.start_link()
-        events = run_commands(cmds)
+        events = run_commands(__MODULE__, cmds)
         Counter.stop()
 
         (events.result == :ok)
@@ -55,7 +55,7 @@ defmodule PropCheck.Test.CounterDSL do
     forall cmds <- commands(__MODULE__) do
       trap_exit do
         {:ok, _pid} = Counter.start_link(5)
-        events = run_commands(cmds)
+        events = run_commands(__MODULE__, cmds)
         Counter.stop()
 
         (events.result == :ok)

--- a/test/movie_dsl_test.exs
+++ b/test/movie_dsl_test.exs
@@ -6,7 +6,7 @@ defmodule PropCheck.Test.MoviesDSL do
   use PropCheck, default_opts: &PropCheck.TestHelpers.config/0
   use PropCheck.StateM.DSL
   use ExUnit.Case
-  import PropCheck.TestHelpers, except: [config: 0]
+  # import PropCheck.TestHelpers, except: [config: 0]
   require Logger
 
   alias PropCheck.Test.MovieServer
@@ -21,7 +21,7 @@ defmodule PropCheck.Test.MoviesDSL do
     forall cmds <- commands(__MODULE__) do
       trap_exit do
         {:ok, _pid} = MovieServer.start_link()
-        events = run_commands(cmds)
+        events = run_commands(__MODULE__, cmds)
         MovieServer.stop
 
         (events.result == :ok)
@@ -42,7 +42,7 @@ defmodule PropCheck.Test.MoviesDSL do
     forall cmds <- commands(__MODULE__) do
       trap_exit do
         {:ok, _pid} = MovieServer.start_link(will_fail: true)
-        events = run_commands(cmds)
+        events = run_commands(__MODULE__, cmds)
         MovieServer.stop
 
         (events.result == :ok)

--- a/test/movie_dsl_test.exs
+++ b/test/movie_dsl_test.exs
@@ -36,6 +36,27 @@ defmodule PropCheck.Test.MoviesDSL do
       end
     end
   end
+
+  @tag will_fail: true
+  property "server has illegal states" do
+    forall cmds <- commands(__MODULE__) do
+      trap_exit do
+        {:ok, _pid} = MovieServer.start_link(will_fail: true)
+        events = run_commands(cmds)
+        MovieServer.stop
+
+        (events.result == :ok)
+        |> when_fail(
+            IO.puts """
+            History: #{inspect events.history, pretty: true}
+            State: #{inspect events.state, pretty: true}
+            Env: #{inspect events.env, pretty: true}
+            Result: #{inspect events.result, pretty: true}
+            """)
+        # |> aggregate(command_names cmds)
+      end
+    end
+  end
   #########################################################################
   ### Model state
   #########################################################################

--- a/test/pingpong_dsl_test.exs
+++ b/test/pingpong_dsl_test.exs
@@ -17,7 +17,7 @@ defmodule PropCheck.Test.PingPongDSL do
       trap_exit do
         assert [] == player_processes()
         PingPongMaster.start_link()
-        events = run_commands(cmds)
+        events = run_commands(__MODULE__, cmds)
         :ok = PingPongMaster.stop()
 
         (events.result == :ok)

--- a/test/support/movie_server.ex
+++ b/test/support/movie_server.ex
@@ -68,7 +68,7 @@ defmodule PropCheck.Test.MovieServer do
     Enum.random([:bon_appetit, :bon_appetit, :bon_appetit,
       :bon_appetit, :bon_appetit, :bon_appetit,
       :bon_appetit, :bon_appetit, :bon_appetit,
-      :fuck_off])
+      :popcorn_is_out])
 
   def handle_call(:popcorn, _from, s),
     do: {:reply, popcorn_answer(s), s}

--- a/test/support/movie_server.ex
+++ b/test/support/movie_server.ex
@@ -59,7 +59,11 @@ defmodule PropCheck.Test.MovieServer do
     :ok
   end
 
-  def handle_call(:popcorn, _from, s), do: {:reply, :bon_appetit, s}
+  def handle_call(:popcorn, _from, s),
+    do: {:reply, Enum.random([:bon_appetit, :bon_appetit, :bon_appetit,
+                              :bon_appetit, :bon_appetit, :bon_appetit,
+                              :bon_appetit, :bon_appetit, :bon_appetit,
+                              :fuck_off]), s}
   def handle_call(:stop, _from, s), do: {:stop, :normal, :stopped, s}
   def handle_call({:new_account, name}, _from, s = %__MODULE__{next_pass: p, users: u}) do
     :ets.insert(u, {p, name, []})


### PR DESCRIPTION
As explained in #131, a refactoring of the stjatemachine DSL removes the state from generated commands. This requires an API change, rendering the `run_commands/1` as deprecated. 

To easier test failing systems, the movie server now has a parameter to introduce failures programmatically. 

Kudos for @x4lldux for the initial steps.