### PR TITLE
Ignore error that happens in travis for elixir 1.6 and 1.7

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,5 +1,6 @@
 [
   ~r/\:contract_(supertype|subtype|diff)/,
   {"test/support/sequential_cache.ex", :race_condition},
-  ~r/lib\/statem_dsl\.ex\:476\:invalid_contract/
+  ~r/lib\/statem_dsl\.ex\:476\:invalid_contract/,
+  {"lib/statem_dsl.ex", :pattern_match}
 ]


### PR DESCRIPTION
Their OTP versions are also older (1.6 uses OTP 19), so there may be why we have those weird errors…

Ignoring these warnings for now, we could clean it up in the future when package doesn't support these versions anymore.