### PR TITLE
Document type specs in StateM modules

### DIFF
--- a/lib/fsm.ex
+++ b/lib/fsm.ex
@@ -110,16 +110,16 @@ defmodule PropCheck.FSM do
   @type mod_name :: atom
   @type state_name :: atom | tuple
   @type state_data :: any
-  @type symb_call :: PropCheck.StateM.symb_call
-  @type symb_var :: PropCheck.StateM.symb_var
+  @type symbolic_call :: PropCheck.StateM.symbolic_call
+  @type symbolic_var :: PropCheck.StateM.symbolic_var
   @type fsm_state()    :: {state_name, state_data}
-  @type transition()   :: {state_name, symb_call}
+  @type transition()   :: {state_name, symbolic_call}
   @type history()      :: [{fsm_state, cmd_result}]
 
   @type result :: :proper_statem.statem_result
   @type fsm_result :: result
   @type cmd_result :: any
-  @type command  :: {:set, symb_var, symb_call} | {:init, fsm_state()}
+  @type command  :: {:set, symbolic_var, symbolic_call} | {:init, fsm_state()}
   @type command_list:: [command]
 
   @doc """
@@ -149,7 +149,7 @@ defmodule PropCheck.FSM do
   will be raised.
   """
   @callback precondition(from :: state_name, target:: state_name,
-    state_data :: state_data, call :: symb_call) :: boolean
+    state_data :: state_data, call :: symbolic_call) :: boolean
 
   @doc """
   Similar to `c:PropCheck.StateM.postcondition/3`. Specifies the
@@ -157,7 +157,7 @@ defmodule PropCheck.FSM do
   of `call`.
   """
   @callback postcondition(from :: state_name, target:: state_name,
-    state_data :: state_data, call :: symb_call, result :: result) :: boolean
+    state_data :: state_data, call :: symbolic_call, result :: result) :: boolean
 
   @doc """
   Similar to `c:PropCheck.StateM.next_state/3`. Specifies how the
@@ -166,7 +166,7 @@ defmodule PropCheck.FSM do
   symbolic or dynamic.
   """
   @callback next_state_data(from :: state_name, target:: state_name,
-    state_data :: state_data, result :: result, call :: symb_call) :: state_data
+    state_data :: state_data, result :: result, call :: symbolic_call) :: state_data
 
   @doc """
   This is an optional callback. When it is not defined (or not exported),
@@ -175,7 +175,7 @@ defmodule PropCheck.FSM do
   triggered by symbolic call `call`. In this case, each transition is chosen
   with probability proportional to the weight assigned.
   """
-  @callback weight(from::state_name, target::state_name, call::symb_call) :: integer
+  @callback weight(from::state_name, target::state_name, call::symbolic_call) :: integer
   @optional_callbacks weight: 3
 
   @doc """

--- a/lib/statem.ex
+++ b/lib/statem.ex
@@ -174,7 +174,7 @@ defmodule PropCheck.StateM do
   @type command :: {:set, symb_var, symb_call} | {:init, symbolic_state}
   @type parallel_testcase :: {command_list, [command_list]}
   @type command_list :: [command]
-  @type history :: [{command, term}]
+  @type history :: [{dynamic_state, term}]
   @type result :: :proper_statem.statem_result
 
   @doc """

--- a/lib/statem/model_dsl.ex
+++ b/lib/statem/model_dsl.ex
@@ -178,14 +178,61 @@ defmodule PropCheck.StateM.ModelDSL do
         end
   """
 
-  @type symb_var :: :proper_statem.symbolic_var()
+  @typedoc """
+  Each result of a symbolic call is stored in a symbolic variable. Their values
+  are opaque and can only used as whole.
+  """
+  @type symbolic_var :: :proper_statem.symbolic_var()
+
+  @typedoc """
+  A symbolic state can be anything and appears only during phase 1.
+  """
   @type symbolic_state :: any
+
+  @typedoc """
+  A dynamic state can be anything and appears only during phase 2.
+  """
   @type dynamic_state :: any
-  @type symb_call :: :proper_statem.symbolic_call()
-  @type command :: {:set, symb_var, symb_call} | {:init, symbolic_state}
-  @type parallel_testcase :: {command_list, [command_list]}
+
+  @typedoc """
+  A symbolic call is the typical mfa-tuple plus the tag `:call`.
+  """
+  @type symbolic_call :: :proper_statem.symbolic_call()
+
+  @typedoc """
+  A value of type `command` denotes the execution of a symbolic command and
+  storing its result in a symbolic variable.
+  """
+  @type command :: {:set, symbolic_var, symbolic_call} | {:init, symbolic_state}
+
+  @typedoc """
+  A sequence of commands.
+  """
   @type command_list :: [command]
+
+  @typedoc """
+  A parallel testcase consists of a sequential and a parallel component. The
+  sequential component is a command sequence that is run first to put the system
+  in a random state. The parallel component is a list containing 2 command
+  sequences to be executed in parallel, each of them in a separate newly-spawned
+  process.
+  """
+  @type parallel_testcase :: {command_list, [command_list]}
+
+  @typedoc """
+  The history of concurrent execution of commands in phase 2.
+  """
+  @type parallel_history :: [{command, term}]
+
+  @typedoc """
+  History of command execution in phase 2. It contains current dynamic state and
+  the result of the call.
+  """
   @type history :: [{dynamic_state, term}]
+
+  @typedoc """
+  The outcome of the command sequence execution.
+  """
   @type result :: :proper_statem.statem_result
 
   @doc """
@@ -204,7 +251,7 @@ defmodule PropCheck.StateM.ModelDSL do
   Generates a symbolic call to be included in the command sequence, given the
   current state `s` of the abstract state machine. Must return a type that
   generates tuples
-  `{command_name :: atom, args :: list(PropCheck.BasicTypes.type)}`.
+  `{command_name :: atom, args :: [PropCheck.BasicTypes.type]}`.
 
   However, before the call is actually included, a precondition is checked. This
   function will be repeatedly called to produce the next call to be included in

--- a/lib/statem/model_dsl.ex
+++ b/lib/statem/model_dsl.ex
@@ -185,7 +185,7 @@ defmodule PropCheck.StateM.ModelDSL do
   @type command :: {:set, symb_var, symb_call} | {:init, symbolic_state}
   @type parallel_testcase :: {command_list, [command_list]}
   @type command_list :: [command]
-  @type history :: [{command, term}]
+  @type history :: [{dynamic_state, term}]
   @type result :: :proper_statem.statem_result
 
   @doc """


### PR DESCRIPTION
Documentation of types is added for both StateM and StateM.ModelDSL.