### PR TITLE
Fix crash in Reporter on passing init state to run_commands

### DIFF
--- a/lib/statem/reporter.ex
+++ b/lib/statem/reporter.ex
@@ -61,6 +61,8 @@ defmodule PropCheck.StateM.Reporter do
   end
 
   @header String.duplicate("=", 80)
+  defp print_pretty_report(title, cmds_to_print, history, state, [{:init, _} | commands], opts),
+    do: print_pretty_report(title, cmds_to_print, history, state, commands, opts)
   defp print_pretty_report(title, cmds_to_print, history, state, commands, opts) do
     main = main_section(cmds_to_print, history, state, commands, opts)
     IO.puts """

--- a/test/cache_dsl_test.exs
+++ b/test/cache_dsl_test.exs
@@ -14,7 +14,7 @@ defmodule PropCheck.Test.Cache.DSL do
   @cache_size 10
 
   property "run the sequential cache" do
-    forall cmds <- commands(__MODULE__) do
+    forall cmds <- commands(__MODULE__, initial_state()) do
       # Logger.debug "Commands to run: #{inspect cmds}"
       Cache.start_link(@cache_size)
       r = run_commands(__MODULE__, cmds)

--- a/test/statem_modeldsl_pretty_reports_test.exs
+++ b/test/statem_modeldsl_pretty_reports_test.exs
@@ -548,6 +548,40 @@ defmodule PropCheck.Test.PrettyReportsDSL do
     end
   end
 
+  describe "initial state passed to `run_commands`," do
+    defp run_cmds(args = [cmd_seq | _]) do
+      strip_ansi_sequences capture_io(fn ->
+        PropCheck.StateM
+        |> apply(:run_commands, [__MODULE__ | args])
+        |> print_report(cmd_seq)
+      end)
+    end
+
+    test "doesn't change a ok printout" do
+      assert run_cmds([ok_seq()]) == run_cmds([ok_seq(), initial_state()])
+    end
+
+    test "doesn't change a command crash printout" do
+      assert run_cmds([command_crash_seq()]) == run_cmds([command_crash_seq(), initial_state()])
+    end
+
+    test "doesn't change a precond fail printout" do
+      assert run_cmds([precond_fail_seq()]) == run_cmds([precond_fail_seq(), initial_state()])
+    end
+
+    test "doesn't change a precond crash printout" do
+      assert run_cmds([precond_crash_seq()]) == run_cmds([precond_crash_seq(), initial_state()])
+    end
+
+    test "doesn't change a postcond fail printout" do
+      assert run_cmds([postcond_fail_seq()]) == run_cmds([postcond_fail_seq(), initial_state()])
+    end
+
+    test "doesn't change a postcond crash printout" do
+      assert run_cmds([postcond_crash_seq()]) == run_cmds([postcond_crash_seq(), initial_state()])
+    end
+  end
+
   describe "printout options," do
     defp run(opts) do
       cmds = postcond_fail_seq()
@@ -662,6 +696,15 @@ defmodule PropCheck.Test.PrettyReportsDSL do
   #
   # Helpers
   #
+
+  defp ok_seq, do: [
+    {:set, {:var, 1}, {:call, __MODULE__, :noop, [0]}},
+    {:set, {:var, 1}, {:call, __MODULE__, :noop, [1]}},
+    {:set, {:var, 1}, {:call, __MODULE__, :noop, [2]}},
+    {:set, {:var, 1}, {:call, __MODULE__, :noop, [3]}},
+    {:set, {:var, 1}, {:call, __MODULE__, :noop, [4]}},
+    {:set, {:var, 1}, {:call, __MODULE__, :noop, [5]}},
+  ]
 
   defp command_crash_seq, do: [
     {:set, {:var, 1}, {:call, __MODULE__, :noop, [0]}},

--- a/test/statem_pretty_reports_test.exs
+++ b/test/statem_pretty_reports_test.exs
@@ -548,6 +548,40 @@ defmodule PropCheck.Test.PrettyReports do
     end
   end
 
+  describe "initial state passed to `run_commands`," do
+    defp run_cmds(args = [cmd_seq | _]) do
+      strip_ansi_sequences capture_io(fn ->
+        PropCheck.StateM
+        |> apply(:run_commands, [__MODULE__ | args])
+        |> print_report(cmd_seq)
+      end)
+    end
+
+    test "doesn't change a ok printout" do
+      assert run_cmds([ok_seq()]) == run_cmds([ok_seq(), initial_state()])
+    end
+
+    test "doesn't change a command crash printout" do
+      assert run_cmds([command_crash_seq()]) == run_cmds([command_crash_seq(), initial_state()])
+    end
+
+    test "doesn't change a precond fail printout" do
+      assert run_cmds([precond_fail_seq()]) == run_cmds([precond_fail_seq(), initial_state()])
+    end
+
+    test "doesn't change a precond crash printout" do
+      assert run_cmds([precond_crash_seq()]) == run_cmds([precond_crash_seq(), initial_state()])
+    end
+
+    test "doesn't change a postcond fail printout" do
+      assert run_cmds([postcond_fail_seq()]) == run_cmds([postcond_fail_seq(), initial_state()])
+    end
+
+    test "doesn't change a postcond crash printout" do
+      assert run_cmds([postcond_crash_seq()]) == run_cmds([postcond_crash_seq(), initial_state()])
+    end
+  end
+
   describe "printout options," do
     defp run(opts) do
       cmds = postcond_fail_seq()
@@ -668,6 +702,15 @@ defmodule PropCheck.Test.PrettyReports do
   #
   # Helpers
   #
+
+  defp ok_seq, do: [
+    {:set, {:var, 1}, {:call, __MODULE__, :noop, [0]}},
+    {:set, {:var, 1}, {:call, __MODULE__, :noop, [1]}},
+    {:set, {:var, 1}, {:call, __MODULE__, :noop, [2]}},
+    {:set, {:var, 1}, {:call, __MODULE__, :noop, [3]}},
+    {:set, {:var, 1}, {:call, __MODULE__, :noop, [4]}},
+    {:set, {:var, 1}, {:call, __MODULE__, :noop, [5]}},
+  ]
 
   defp command_crash_seq, do: [
     {:set, {:var, 1}, {:call, __MODULE__, :noop, [0]}},


### PR DESCRIPTION
Passing a third argument to `run_commands/3` in `StateM` or
`StateM.ModelDSL`, an explicit initial state to be used instead of a
callback, and then using `StateM.Reporter` caused a crash on printing it
out.