### PR TITLE
Fix a flaky test

### DIFF
--- a/test/cache_dsl_test.exs
+++ b/test/cache_dsl_test.exs
@@ -75,7 +75,7 @@ defmodule PropCheck.Test.Cache.DSL do
   # Testing the command generators and such
 
   test "commands produces something" do
-    cmd_gen = commands(__MODULE__)
+    cmd_gen = commands(__MODULE__) |> non_empty()
     size = 10
     {:ok, cmds} = produce(cmd_gen, size)
 


### PR DESCRIPTION
PropEr's command generator may return an empty sequence. We need to
explicitly disallow it here.