### PR TITLE
Pretty print StateM command sequence counterexample output

### DIFF
--- a/lib/statem/model_dsl.ex
+++ b/lib/statem/model_dsl.ex
@@ -281,7 +281,7 @@ defmodule PropCheck.StateM.ModelDSL do
     ]
   end
 
-  def def_commands() do
+  def def_commands do
     quote do
       def __all_commands__, do: @commands
 

--- a/test/cache_dsl_test.exs
+++ b/test/cache_dsl_test.exs
@@ -6,7 +6,6 @@ defmodule PropCheck.Test.Cache.DSL do
   use ExUnit.Case, async: true
   use PropCheck, default_opts: &PropCheck.TestHelpers.config/0
   use PropCheck.StateM.ModelDSL
-  import PropCheck.TestHelpers, except: [config: 0]
 
   alias PropCheck.Test.Cache
   # require Logger
@@ -17,7 +16,8 @@ defmodule PropCheck.Test.Cache.DSL do
     forall cmds <- commands(__MODULE__, initial_state()) do
       # Logger.debug "Commands to run: #{inspect cmds}"
       Cache.start_link(@cache_size)
-      r = run_commands(__MODULE__, cmds)
+      env = [just_a_var: 123, root_key: 0]
+      r = run_commands(__MODULE__, cmds, env)
       {_history, _state, result} = r
       Cache.stop()
       # Logger.debug "Events are: #{inspect events}"
@@ -98,9 +98,11 @@ defmodule PropCheck.Test.Cache.DSL do
   to 'fuzz' the system.
   """
   def key, do: oneof([
-    integer(1, @cache_size),
-    integer()
-    ])
+        integer(1, @cache_size),
+        integer(),
+        {:var, :just_a_var},
+        {:var, :root_key}
+      ])
   @doc "our values are integers"
   def val, do: integer()
 


### PR DESCRIPTION
Instead of printing generated commands counter example as a list of
`{:set, {:var, _}, {:call, _mod, _fun, _args}}` tuples, prints similar
output as `StateM.Reporter` does:

```
  1) property run the misconfigured sequential cache (PropCheck.Test.Cache.DSL)
     test/cache_dsl_test.exs:38
     Property Elixir.PropCheck.Test.Cache.DSL.property run the misconfigured sequential cache() failed. Counter-Example is:
     var6 = PropCheck.Test.Cache.DSL.cache(10, -13)
     var7 = PropCheck.Test.Cache.DSL.cache(1, -17)
     var8 = PropCheck.Test.Cache.DSL.cache(9, -1)
     var9 = PropCheck.Test.Cache.DSL.cache(4, 6)
     var10 = PropCheck.Test.Cache.DSL.cache(-10, 3)
     var13 = PropCheck.Test.Cache.DSL.cache(var_root_key, 12)
     var14 = PropCheck.Test.Cache.DSL.find(10)
     
     
     Counter example stored.
     
     code: nil
     stacktrace:
       (propcheck) lib/properties.ex:226: PropCheck.Properties.handle_check_results/2
       test/cache_dsl_test.exs:38: (test)
```
Unfortunately, even if the failing command is the first, it will print the
entire command list that is being stored as a counter example, and not just the
first one like `StateM.Reporter` would print. But this shouldn't happen often
because the minimization process should reduce the list.