### PR TITLE
Pretty print StateM commands in aliased form

### DIFF
--- a/lib/statem.ex
+++ b/lib/statem.ex
@@ -367,7 +367,7 @@ defmodule PropCheck.StateM do
 
   * `history` contains the execution history of all commands that were
     executed without raising an exception. It contains tuples of the form
-    `{t:dynamic_state, t:term}`, specifying the state prior to
+    `{t:dynamic_state/0, t:term/0}`, specifying the state prior to
     command execution and the actual result of the command.
   * `dynamicState` contains the state of the abstract state machine at
     the moment when execution stopped. In case execution has stopped due to a
@@ -444,6 +444,9 @@ defmodule PropCheck.StateM do
   @doc """
   Print pretty report of the failed command run.
 
+  Note that it by default aliases every commands module, so only the last part
+  of the namespace will be used.
+
   Accepts options:
   * `return_values` - whether to print return values after each command run
     (default `true`),
@@ -456,7 +459,10 @@ defmodule PropCheck.StateM do
   * `cmd_args` - whether to print command arguments as literals
     (default `true`),
   * `inspect_opts` - options passed to `inspect/2`
-
+  * `alias` - set a list of modules and aliases, to be used to pretty print
+  commands. Accepts a `t:module/0`,  a tuple of type
+  `{module(), alias :: module()}` or a list of them (default is to alias every
+  command's module - if you want to disable default aliasing set it to `[]`).
   """
   @spec print_report({history, dynamic_state, result}, command_list, keyword) :: :ok
   defdelegate print_report(run_result, cmds, opts \\ []),

--- a/lib/statem/model_dsl.ex
+++ b/lib/statem/model_dsl.ex
@@ -526,6 +526,9 @@ defmodule PropCheck.StateM.ModelDSL do
   @doc """
   Print pretty report of the failed command run.
 
+  Note that it by default aliases every commands module, so only the last part
+  of the namespace will be used.
+
   Accepts options:
   * `return_values` - whether to print return values after each command run
   (default `true`),
@@ -538,6 +541,10 @@ defmodule PropCheck.StateM.ModelDSL do
   * `cmd_args` - whether to print command arguments as literals
   (default `true`),
   * `inspect_opts` - options passed to `inspect/2`
+  * `alias` - set a list of modules and aliases, to be used to pretty print
+  commands. Accepts a `t:module/0`,  a tuple of type
+  `{module(), alias :: module()}` or a list of them (default is to alias every
+  command's module - if you want to disable default aliasing set it to `[]`).
   """
   defdelegate print_report(run_result, cmds, opts \\ []),
     to: PropCheck.StateM.Reporter

--- a/test/statem_modeldsl_pretty_reports_test.exs
+++ b/test/statem_modeldsl_pretty_reports_test.exs
@@ -11,23 +11,23 @@ defmodule PropCheck.Test.PrettyReportsDSL do
     # Command crashed.
     #
     # Commands:
-    #    var1 = PropCheck.Test.PrettyReportsDSL.noop(0)
+    #    var1 = PrettyReportsDSL.noop(0)
     #         # -> :ok
     #         # Post state: [0]
     #
-    #    var2 = PropCheck.Test.PrettyReportsDSL.noop(1)
+    #    var2 = PrettyReportsDSL.noop(1)
     #         # -> :ok
     #         # Post state: [1, 0]
     #
-    #    var3 = PropCheck.Test.PrettyReportsDSL.noop(2)
+    #    var3 = PrettyReportsDSL.noop(2)
     #         # -> :ok
     #         # Post state: [2, 1, 0]
     #
-    #    var4 = PropCheck.Test.PrettyReportsDSL.noop(3)
+    #    var4 = PrettyReportsDSL.noop(3)
     #         # -> :ok
     #         # Post state: [3, 2, 1, 0]
     #
-    # #! var5 = PropCheck.Test.PrettyReportsDSL.crash_command()
+    # #! var5 = PrettyReportsDSL.crash_command()
     #         # -> ** (RuntimeError) Crash
     #         #     test/statem_pretty_reports_test.exs:99: PropCheck.Test.PrettyReportsDSL.crash_command/0
     #         #     (proper) src/proper_statem.erl:581: :proper_statem.safe_apply/3
@@ -139,22 +139,22 @@ defmodule PropCheck.Test.PrettyReportsDSL do
     #
     #
     # Commands:
-    #    var1 = PropCheck.Test.PrettyReportsDSL.noop(0)
+    #    var1 = PrettyReportsDSL.noop(0)
     #         # -> :ok
     #         # Post state: [0]
     #
-    #    var2 = PropCheck.Test.PrettyReportsDSL.noop(1)
+    #    var2 = PrettyReportsDSL.noop(1)
     #         # -> :ok
     #         # Post state: [1, 0]
     #
-    #    var3 = PropCheck.Test.PrettyReportsDSL.noop(2)
+    #    var3 = PrettyReportsDSL.noop(2)
     #         # -> :ok
     #         # Post state: [2, 1, 0]
     #
-    #    var4 = PropCheck.Test.PrettyReportsDSL.noop(3)
+    #    var4 = PrettyReportsDSL.noop(3)
     #         # -> :ok
     #
-    # #! var5 = PropCheck.Test.PrettyReportsDSL.crash_precond()
+    # #! var5 = PrettyReportsDSL.crash_precond()
     #
     #
     # Last state:
@@ -237,22 +237,22 @@ defmodule PropCheck.Test.PrettyReportsDSL do
     # Precondition failed.
     #
     # Commands:
-    #    var1 = PropCheck.Test.PrettyReportsDSL.noop(0)
+    #    var1 = PrettyReportsDSL.noop(0)
     #         # -> :ok
     #         # Post state: [0]
     #
-    #    var2 = PropCheck.Test.PrettyReportsDSL.noop(1)
+    #    var2 = PrettyReportsDSL.noop(1)
     #         # -> :ok
     #         # Post state: [1, 0]
     #
-    #    var3 = PropCheck.Test.PrettyReportsDSL.noop(2)
+    #    var3 = PrettyReportsDSL.noop(2)
     #         # -> :ok
     #         # Post state: [2, 1, 0]
     #
-    #    var4 = PropCheck.Test.PrettyReportsDSL.noop(3)
+    #    var4 = PrettyReportsDSL.noop(3)
     #         # -> :ok
     #
-    # #! var5 = PropCheck.Test.PrettyReportsDSL.fail_precond()
+    # #! var5 = PrettyReportsDSL.fail_precond()
     #
     #
     # Last state:
@@ -351,23 +351,23 @@ defmodule PropCheck.Test.PrettyReportsDSL do
     #
     #
     # Commands:
-    #    var1 = PropCheck.Test.PrettyReportsDSL.noop(0)
+    #    var1 = PrettyReportsDSL.noop(0)
     #         # -> :ok
     #         # Post state: [0]
     #
-    #    var2 = PropCheck.Test.PrettyReportsDSL.noop(1)
+    #    var2 = PrettyReportsDSL.noop(1)
     #         # -> :ok
     #         # Post state: [1, 0]
     #
-    #    var3 = PropCheck.Test.PrettyReportsDSL.noop(2)
+    #    var3 = PrettyReportsDSL.noop(2)
     #         # -> :ok
     #         # Post state: [2, 1, 0]
     #
-    #    var4 = PropCheck.Test.PrettyReportsDSL.noop(3)
+    #    var4 = PrettyReportsDSL.noop(3)
     #         # -> :ok
     #         # Post state: [3, 2, 1, 0]
     #
-    # #! var5 = PropCheck.Test.PrettyReportsDSL.crash_postcond()
+    # #! var5 = PrettyReportsDSL.crash_postcond()
     #         # -> :ok
     #
     #
@@ -451,23 +451,23 @@ defmodule PropCheck.Test.PrettyReportsDSL do
     # Postcondition failed.
     #
     # Commands:
-    #    var1 = PropCheck.Test.PrettyReportsDSL.noop(0)
+    #    var1 = PrettyReportsDSL.noop(0)
     #         # -> :ok
     #         # Post state: [0]
     #
-    #    var2 = PropCheck.Test.PrettyReportsDSL.noop(1)
+    #    var2 = PrettyReportsDSL.noop(1)
     #         # -> :ok
     #         # Post state: [1, 0]
     #
-    #    var3 = PropCheck.Test.PrettyReportsDSL.noop(2)
+    #    var3 = PrettyReportsDSL.noop(2)
     #         # -> :ok
     #         # Post state: [2, 1, 0]
     #
-    #    var4 = PropCheck.Test.PrettyReportsDSL.noop(3)
+    #    var4 = PrettyReportsDSL.noop(3)
     #         # -> :ok
     #         # Post state: [3, 2, 1, 0]
     #
-    # #! var5 = PropCheck.Test.PrettyReportsDSL.fail_postcond()
+    # #! var5 = PrettyReportsDSL.fail_postcond()
     #         # -> :ok
     #
     #
@@ -624,16 +624,42 @@ defmodule PropCheck.Test.PrettyReportsDSL do
 
     test "command arguments as literals is enabled by default" do
       c = run []
+      assert c.log =~ "var1 = PrettyReportsDSL.noop(0)"
+      assert c.log =~ "var2 = PrettyReportsDSL.noop(1)"
+      assert c.log =~ "var3 = PrettyReportsDSL.noop(2)"
+    end
+
+    test "command arguments as literals can be suppressed" do
+      c = run [cmd_args: false]
+      assert c.log =~ "var1 = PrettyReportsDSL.noop(arg1_1)"
+      assert c.log =~ "var2 = PrettyReportsDSL.noop(arg2_1)"
+      assert c.log =~ "var3 = PrettyReportsDSL.noop(arg3_1)"
+    end
+
+    test "module aliasing can be disabled" do
+      c = run [alias: []]
       assert c.log =~ "var1 = PropCheck.Test.PrettyReportsDSL.noop(0)"
       assert c.log =~ "var2 = PropCheck.Test.PrettyReportsDSL.noop(1)"
       assert c.log =~ "var3 = PropCheck.Test.PrettyReportsDSL.noop(2)"
     end
 
-    test "command arguments as literals can be suppressed" do
-      c = run [cmd_args: false]
-      assert c.log =~ "var1 = PropCheck.Test.PrettyReportsDSL.noop(arg1_1)"
-      assert c.log =~ "var2 = PropCheck.Test.PrettyReportsDSL.noop(arg2_1)"
-      assert c.log =~ "var3 = PropCheck.Test.PrettyReportsDSL.noop(arg3_1)"
+    test "module aliasing accepts a list and a single element" do
+      c = run [alias: PropCheck.Test.PrettyReportsDSL]
+      assert c.log =~ "var1 = PrettyReportsDSL.noop(0)"
+      assert c.log =~ "var2 = PrettyReportsDSL.noop(1)"
+      assert c.log =~ "var3 = PrettyReportsDSL.noop(2)"
+
+      c = run [alias: [PropCheck.Test.PrettyReportsDSL]]
+      assert c.log =~ "var1 = PrettyReportsDSL.noop(0)"
+      assert c.log =~ "var2 = PrettyReportsDSL.noop(1)"
+      assert c.log =~ "var3 = PrettyReportsDSL.noop(2)"
+    end
+
+    test "module aliasing works in 'alias as' mode" do
+      c = run [alias: [{PropCheck.Test.PrettyReportsDSL, X}]]
+      assert c.log =~ "var1 = X.noop(0)"
+      assert c.log =~ "var2 = X.noop(1)"
+      assert c.log =~ "var3 = X.noop(2)"
     end
   end
 

--- a/test/statem_pretty_reports_test.exs
+++ b/test/statem_pretty_reports_test.exs
@@ -11,23 +11,23 @@ defmodule PropCheck.Test.PrettyReports do
     # Command crashed.
     #
     # Commands:
-    #    var1 = PropCheck.Test.PrettyReports.noop(0)
+    #    var1 = PrettyReports.noop(0)
     #         # -> :ok
     #         # Post state: [0]
     #
-    #    var2 = PropCheck.Test.PrettyReports.noop(1)
+    #    var2 = PrettyReports.noop(1)
     #         # -> :ok
     #         # Post state: [1, 0]
     #
-    #    var3 = PropCheck.Test.PrettyReports.noop(2)
+    #    var3 = PrettyReports.noop(2)
     #         # -> :ok
     #         # Post state: [2, 1, 0]
     #
-    #    var4 = PropCheck.Test.PrettyReports.noop(3)
+    #    var4 = PrettyReports.noop(3)
     #         # -> :ok
     #         # Post state: [3, 2, 1, 0]
     #
-    # #! var5 = PropCheck.Test.PrettyReports.crash_command()
+    # #! var5 = PrettyReports.crash_command()
     #         # -> ** (RuntimeError) Crash
     #         #     test/statem_pretty_reports_test.exs:99: PropCheck.Test.PrettyReports.crash_command/0
     #         #     (proper) src/proper_statem.erl:581: :proper_statem.safe_apply/3
@@ -139,22 +139,22 @@ defmodule PropCheck.Test.PrettyReports do
     #
     #
     # Commands:
-    #    var1 = PropCheck.Test.PrettyReports.noop(0)
+    #    var1 = PrettyReports.noop(0)
     #         # -> :ok
     #         # Post state: [0]
     #
-    #    var2 = PropCheck.Test.PrettyReports.noop(1)
+    #    var2 = PrettyReports.noop(1)
     #         # -> :ok
     #         # Post state: [1, 0]
     #
-    #    var3 = PropCheck.Test.PrettyReports.noop(2)
+    #    var3 = PrettyReports.noop(2)
     #         # -> :ok
     #         # Post state: [2, 1, 0]
     #
-    #    var4 = PropCheck.Test.PrettyReports.noop(3)
+    #    var4 = PrettyReports.noop(3)
     #         # -> :ok
     #
-    # #! var5 = PropCheck.Test.PrettyReports.crash_precond()
+    # #! var5 = PrettyReports.crash_precond()
     #
     #
     # Last state:
@@ -237,22 +237,22 @@ defmodule PropCheck.Test.PrettyReports do
     # Precondition failed.
     #
     # Commands:
-    #    var1 = PropCheck.Test.PrettyReports.noop(0)
+    #    var1 = PrettyReports.noop(0)
     #         # -> :ok
     #         # Post state: [0]
     #
-    #    var2 = PropCheck.Test.PrettyReports.noop(1)
+    #    var2 = PrettyReports.noop(1)
     #         # -> :ok
     #         # Post state: [1, 0]
     #
-    #    var3 = PropCheck.Test.PrettyReports.noop(2)
+    #    var3 = PrettyReports.noop(2)
     #         # -> :ok
     #         # Post state: [2, 1, 0]
     #
-    #    var4 = PropCheck.Test.PrettyReports.noop(3)
+    #    var4 = PrettyReports.noop(3)
     #         # -> :ok
     #
-    # #! var5 = PropCheck.Test.PrettyReports.fail_precond()
+    # #! var5 = PrettyReports.fail_precond()
     #
     #
     # Last state:
@@ -351,23 +351,23 @@ defmodule PropCheck.Test.PrettyReports do
     #
     #
     # Commands:
-    #    var1 = PropCheck.Test.PrettyReports.noop(0)
+    #    var1 = PrettyReports.noop(0)
     #         # -> :ok
     #         # Post state: [0]
     #
-    #    var2 = PropCheck.Test.PrettyReports.noop(1)
+    #    var2 = PrettyReports.noop(1)
     #         # -> :ok
     #         # Post state: [1, 0]
     #
-    #    var3 = PropCheck.Test.PrettyReports.noop(2)
+    #    var3 = PrettyReports.noop(2)
     #         # -> :ok
     #         # Post state: [2, 1, 0]
     #
-    #    var4 = PropCheck.Test.PrettyReports.noop(3)
+    #    var4 = PrettyReports.noop(3)
     #         # -> :ok
     #         # Post state: [3, 2, 1, 0]
     #
-    # #! var5 = PropCheck.Test.PrettyReports.crash_postcond()
+    # #! var5 = PrettyReports.crash_postcond()
     #         # -> :ok
     #
     #
@@ -451,23 +451,23 @@ defmodule PropCheck.Test.PrettyReports do
     # Postcondition failed.
     #
     # Commands:
-    #    var1 = PropCheck.Test.PrettyReports.noop(0)
+    #    var1 = PrettyReports.noop(0)
     #         # -> :ok
     #         # Post state: [0]
     #
-    #    var2 = PropCheck.Test.PrettyReports.noop(1)
+    #    var2 = PrettyReports.noop(1)
     #         # -> :ok
     #         # Post state: [1, 0]
     #
-    #    var3 = PropCheck.Test.PrettyReports.noop(2)
+    #    var3 = PrettyReports.noop(2)
     #         # -> :ok
     #         # Post state: [2, 1, 0]
     #
-    #    var4 = PropCheck.Test.PrettyReports.noop(3)
+    #    var4 = PrettyReports.noop(3)
     #         # -> :ok
     #         # Post state: [3, 2, 1, 0]
     #
-    # #! var5 = PropCheck.Test.PrettyReports.fail_postcond()
+    # #! var5 = PrettyReports.fail_postcond()
     #         # -> :ok
     #
     #
@@ -624,16 +624,42 @@ defmodule PropCheck.Test.PrettyReports do
 
     test "command arguments as literals is enabled by default" do
       c = run []
+      assert c.log =~ "var1 = PrettyReports.noop(0)"
+      assert c.log =~ "var2 = PrettyReports.noop(1)"
+      assert c.log =~ "var3 = PrettyReports.noop(2)"
+    end
+
+    test "command arguments as literals can be suppressed" do
+      c = run [cmd_args: false]
+      assert c.log =~ "var1 = PrettyReports.noop(arg1_1)"
+      assert c.log =~ "var2 = PrettyReports.noop(arg2_1)"
+      assert c.log =~ "var3 = PrettyReports.noop(arg3_1)"
+    end
+
+    test "module aliasing can be disabled" do
+      c = run [alias: []]
       assert c.log =~ "var1 = PropCheck.Test.PrettyReports.noop(0)"
       assert c.log =~ "var2 = PropCheck.Test.PrettyReports.noop(1)"
       assert c.log =~ "var3 = PropCheck.Test.PrettyReports.noop(2)"
     end
 
-    test "command arguments as literals can be suppressed" do
-      c = run [cmd_args: false]
-      assert c.log =~ "var1 = PropCheck.Test.PrettyReports.noop(arg1_1)"
-      assert c.log =~ "var2 = PropCheck.Test.PrettyReports.noop(arg2_1)"
-      assert c.log =~ "var3 = PropCheck.Test.PrettyReports.noop(arg3_1)"
+    test "module aliasing accepts a list and a single element" do
+      c = run [alias: PropCheck.Test.PrettyReports]
+      assert c.log =~ "var1 = PrettyReports.noop(0)"
+      assert c.log =~ "var2 = PrettyReports.noop(1)"
+      assert c.log =~ "var3 = PrettyReports.noop(2)"
+
+      c = run [alias: [PropCheck.Test.PrettyReports]]
+      assert c.log =~ "var1 = PrettyReports.noop(0)"
+      assert c.log =~ "var2 = PrettyReports.noop(1)"
+      assert c.log =~ "var3 = PrettyReports.noop(2)"
+    end
+
+    test "module aliasing works in 'alias as' mode" do
+      c = run [alias: [{PropCheck.Test.PrettyReports, X}]]
+      assert c.log =~ "var1 = X.noop(0)"
+      assert c.log =~ "var2 = X.noop(1)"
+      assert c.log =~ "var3 = X.noop(2)"
     end
   end
 


### PR DESCRIPTION
Commands are printed like this:
`var13 = DSL.cache(var_root_key, 12)`
instead of:
`var13 = PropCheck.Test.Cache.DSL.cache(var_root_key, 12)`