### PR TITLE
Basic instrumentation facilities for parallel testing [WIP]

### DIFF
--- a/lib/instrument.ex
+++ b/lib/instrument.ex
@@ -1,0 +1,179 @@
+defmodule PropCheck.Instrument do
+  @moduledoc """
+  Provides functions and macros for instrument byte code with additional yields and
+  other constructs to ease testing of concurrent programs and state machines.
+  """
+
+  @doc """
+  Takes the object code of the module, instruments it and update the module
+  in the code server with instrumented byte code.
+  """
+  def instrument_module(mod) when is_atom(mod) do
+
+    # TODO: hwo to convert a beam ast to an Elixir ast?
+    # with :beam_lib we can extract the Erlang AST from the obj_code binary
+    # but how to proceed then?
+    # ast = instrument_functions(mod, obj_code)
+    # {^mod, new_obj_code} = Code.compile_quoted(ast, file)
+    # {:module, _new_mod} = :code.load_binary(mod, filename, new_obj_code)
+    :not_implemented
+  end
+
+  @doc """
+  Retrieves the abstract code, i.e. the list of forms, of the given
+  module as found in the code server.
+  """
+  def get_forms_of_module(mod) when is_atom(mod) do
+    {^mod, filename, beam_code} = :code.get_object_code(mod)
+    case :beam_lib.chunks(beam_code, [:abstract_code]) do
+      {:ok, {^mod, [forms]}} -> {:ok, forms}
+      error -> error
+    end
+  end
+
+  @doc "Instruments the form of a module"
+  def instrument_form({:abstract_code, {:raw_abstract_v1, clauses}}) when is_list(clauses) do
+    instr_clauses = Enum.map(clauses, &instrument_mod_clause/1)
+    {:abstract_form,
+      {:raw_abstract_v1,
+        instr_clauses}}
+  end
+
+  @doc "Instruments the clauses of a module"
+  def instrument_mod_clause({:function, line, name, arg_count, body}) do
+    instr_body = Enum.map(body, &instrument_body/1)
+    {:function, line, name, arg_count, body}
+  end
+  def instrument_mod_clause(clause), do: clause
+
+  @doc "Instruments the each body (a `:clause`) of a function"
+  def instrument_body({:clause, line, args, local_vars, exprs}) do
+    instr_exprs = Enum.map(exprs, &instrument_expr/1)
+    {:clause, line, args, local_vars, instr_exprs}
+  end
+
+  @doc "This is a big switch over all kinds of expressions for instrumenting them"
+  def instrument_expr({:atom, _, _} = a), do: a
+  def instrument_expr({:bc, line, expr, qs}) do
+    {:bc, line, instrument_expr(expr), Enum.map(qs, &instrument_qualifier/1)}
+  end
+  def instrument_expr({:bin, line, bin_elements}) do
+    {:bin, line, Enum.map(bin_elements, &instrument_bin_element/1)}
+  end
+  def instrument_expr({:block, line, exprs}) do
+    {:block, line, Enum.map(exprs, &instrument_expr/1)}
+  end
+  def instrument_expr({:case, line, expr, clauses}) do
+    instr_expr = instrument_expr(expr)
+    {:case, line, instr_expr, Enum.map(clauses, &instrument_clause/1)}
+  end
+  def instrument_expr({:catch, line, expr}), do: {:catch, line, instrument_expr(expr)}
+  def instrument_expr({:cons, line, e1, e2}), do: {:cons, line, instrument_expr(e1), instrument_expr(e2)}
+  def instrument_expr({:fun, line, cs}) when is_list(cs) do
+    {:fun, line, Enum.map(cs, &instrument_clause/1)}
+  end
+  def instrument_expr({:fun, _, _} = f), do: f
+  def instrument_expr({:call, _l, _f, _args} = c), do: instrument_function_call(c)
+  def instrument_expr({:remote, _l, _m, _f, _args} = c), do: instrument_function_call(c)
+  def instrument_expr({:if, line, cs}), do: {:if, line, Enum.map(cs, &instrument_clause/1)}
+  def instrument_expr({:lc, line, e, qs}) do
+    {:lc, line, instrument_expr(e), Enum.map(qs, &instrument_qualifier/1)}
+  end
+  def instrument_expr({:map, line, assocs}), do: {:map, line, Enum.map(assocs, &instrument_assoc/1)}
+  def instrument_expr({:map, line, expr, assocs}) do
+    {:map, line, instrument_expr(expr), Enum.map(assocs, &instrument_assoc/1)}
+  end
+  def instrument_expr({:match, line, p, e}) do
+    {:match, line, instrument_pattern(p), instrument_expr(e)}
+  end
+  def instrument_expr({:nil, line}), do: {:nil, line}
+  def instrument_expr({:op, line, op, e1}), do: {:op, line, op, instrument_expr(e1)}
+  def instrument_expr({:op, line, op, e1, e2}), do: {:op, line, op, instrument_expr(e1), instrument_expr(e2)}
+  def instrument_expr({:receive, line, cs} = r), do: instrument_receive(r)
+  def instrument_expr({:receive, line, cs, e, b} = r), do: instrument_receive(r)
+  def instrument_expr({:record, line, name, fields}) do # record creation
+    {:record, line, name, Enum.map(fields, &instrument_expr/1)}
+  end
+  def instrument_expr({:record, line, e, name, fields}) do # record update
+    {:record, line, instrument_expr(e), name, Enum.map(fields, &instrument_expr/1)}
+  end
+  def instrument_expr({:record_field, line, field, expr}), do: {:record, line, field, instrument_expr(expr)}
+  def instrument_expr({:record_field, line, expr, name, field}), do: {:record, line, instrument_expr(expr), name, field}
+  def instrument_expr({:record_index, line, _name, _fields} = r), do: r
+  def instrument_expr({:tuple, line, es}), do: {:tuple, line, Enum.map(es, &instrument_expr/1)}
+  def instrument_expr({:try, line, body, cases, catches, expr}) do
+    i_body = Enum.map(body, &instrument_expr/1)
+    i_cases = Enum.map(cases, &instrument_clause/1)
+    i_catches = Enum.map(catches, &instrument_clause/1)
+    {:try, line, i_body, i_cases, i_catches, instrument_expr(expr)}
+  end
+  def instrument_expr({:var, _l, _name} = v), do: v
+  def instrument_expr({literal, _line, _val} = l) when literal in [:atom, :integer, :float, :char, :string], do: l
+
+
+  def instrument_bin_element({:bin_element, line, expr, size, tsl}) do
+    {:bin_element, line, instrument_expr(expr), size, tsl}
+  end
+
+  @doc "Instrument case, catch, function clauses"
+  def instrument_clause({:clause, line, p, body}) do
+    {:clause, line, instrument_pattern(p), Enum.map(body, &instrument_expr/1)}
+  end
+  def instrument_clause({:clause, line, p, guards, body}) do
+    {:clause, line, instrument_pattern(p), Enum.map(guards, &instrument_expr/1), Enum.map(body, &instrument_expr/1)}
+  end
+
+  @doc "Instrument qualifiers of list and bit comprehensions"
+  def instrument_qualifier({:generate, line, p, e}), do: {:generate, line, instrument_pattern(p), instrument_expr(e)}
+  def instrument_qualifier({:b_generate, line, p, e}), do: {:b_generate, line, instrument_pattern(p), instrument_expr(e)}
+  def instrument_qualifier(e), do: instrument_expr(e)
+
+  @doc "Instrument patterns, which are mostly expressions, except for variables/atoms"
+  def instrument_pattern({x, p, s}), do: {x, instrument_expr(p), s}
+  def instrument_pattern(ps) when is_list(ps), do: Enum.map(ps, &instrument_pattern/1)
+  def instrument_pattern(p), do: instrument_expr(p)
+
+  def instrument_assoc({assoc, line, key, value}) do
+    {assoc, line, instrument_expr(key), instrument_expr(value)}
+  end
+
+
+  def instrument_function_call(c), do: throw "Not Implemented"
+
+  @doc "The receive might be handled differently, therefore it has its own function"
+  def instrument_receive({:receive, line, cs} = r) do
+    {:receive, line, Enum.map(cs, &instrument_clause/1)}
+  end
+  def instrument_receive({:receive, line, cs, e, b} = r) do
+    {:receive, line, Enum.map(cs, &instrument_clause/1), instrument_expr(e), Enum.map(b, &instrument_expr/1)}
+  end
+
+
+  @doc """
+  Instruments the body of a function to handle the `receive do ... end` expression
+  for Tracer
+  """
+  def instrument_elixir_expr(expr, context, instrumenter \\ __MODULE__) do
+    IO.puts "instrument function #{context.name}"
+    instr_expr = Macro.postwalk(expr, fn
+      {:receive, _info, [patterns]} ->
+        # identify do: patterns Und after: clause, diese müssen bei
+        # gen_receive als Argument übernommen werden.
+        IO.puts "instrument receive with pattern #{Macro.to_string patterns}"
+        IO.puts "instrument receive with pattern #{inspect patterns}"
+        IO.puts "Body expression is: #{Macro.to_string expr}"
+        gen_receive(patterns)
+      {:receive, _info, [patterns, _after_pattern]} ->
+        IO.puts "instrument a receive with an after pattern - this is ignored!"
+        gen_receive(patterns)
+      any -> any
+    end)
+    IO.puts "New body is: #{Macro.to_string(instr_expr)}"
+    IO.puts "New body is: #{inspect instr_expr, pretty: true}"
+    instr_expr
+  end
+
+  def gen_receive(patterns) do
+    throw "Not Implemented"
+  end
+end

--- a/lib/instrument.ex
+++ b/lib/instrument.ex
@@ -92,6 +92,10 @@ defmodule PropCheck.Instrument do
       _ -> false
     end)
   end
+  def is_instrumented?(mod) do
+    mod.module_info(:attributes)
+    |> Keyword.has_key?(:instrumented)
+  end
 
   # Helper function for passing the module through the mapping process
   defp map(enum, mod, fun) when is_function(fun, 2) do

--- a/lib/instrument.ex
+++ b/lib/instrument.ex
@@ -13,15 +13,38 @@ defmodule PropCheck.Instrument do
   @callback handle_function_call(call :: any) :: any
 
   @doc """
+  A callback to decide if the function `mod:fun` with any arity is a candidate
+  for instrumentation. The default implementation is simply calling
+  `instrumentable_function/2`.
+  """
+  @callback is_instrumentable_function(mod ::module, fun :: atom) :: boolean
+
+  @doc """
   Takes the object code of the module, instruments it and update the module
   in the code server with instrumented byte code.
   """
-  def instrument_module(mod) when is_atom(mod) do
+  @spec instrument_module(mod :: module, instrumeter :: module) :: any
+  def instrument_module(mod, instrumenter) when is_atom(mod) and is_atom(instrumenter) do
     # 1. Get the forms of the mod
-    # 2. instruments the forms of the mod
-    # 3. Compile them with :compile.forms
-    :not_implemented
+    {:ok, filename, forms} = get_forms_of_module(mod)
+    case is_instrumented?(forms) do
+      false ->
+        # 2. instruments the forms of the mod
+        {:abstract_code, {:raw_abstract_v1, altered_forms}} = instrument_forms(instrumenter, forms)
+        # 3. Compile them with :compile.forms
+        instr_attribute = {:attribute, 1, :instrumented, PropCheck}
+        instrumented_form = add_attribute([instr_attribute], altered_forms)
+        compile_module(mod, filename, instrumented_form)
+      attribute ->
+        Logger.error "Module #{inspect mod} is alread instrumented: #{inspect attribute}"
+    end
   end
+
+  def add_attribute(attrs, forms), do: add_attribute(attrs, [], forms)
+  def add_attribute([], forms, []), do: Enum.reverse(forms)
+  def add_attribute([], fs, [f | tail]), do: add_attribute([], [f | fs], tail)
+  def add_attribute(as, fs1, [{:attribute, _, _, _} = a | tail]), do: add_attribute(as, [a | fs1], tail)
+  def add_attribute([attr | as], fs1, tail), do: add_attribute(as, [attr | fs1], tail)
 
   @doc """
   Retrieves the abstract code, i.e. the list of forms, of the given
@@ -40,6 +63,9 @@ defmodule PropCheck.Instrument do
   the VM.
   """
   def compile_module(mod, filename, {:abstract_code, {:raw_abstract_v1, clauses}} = _abstract_code) do
+    compile_module(mod, filename, clauses)
+  end
+  def compile_module(mod, filename, clauses) when is_list(clauses) do
     options = [:binary, :debug_info, :return, :verbose]
     case :compile.noenv_forms(clauses, options) do
       {:ok, ^mod, bin_code, warnings} ->
@@ -51,6 +77,15 @@ defmodule PropCheck.Instrument do
     end
   end
 
+  @doc "Checks if the code is already instrumented. If not, returns `false` otherwise returns the attribute"
+  def is_instrumented?({:abstract_code, {:raw_abstract_v1, clauses}}), do: is_instrumented?(clauses)
+  def is_instrumented?(clauses) when is_list(clauses) do
+    Enum.find(clauses, false, fn
+      {:attribute, _line, :instrumented, _} -> true
+      _ -> false
+    end)
+  end
+
   # Helper function for passing the module through the mapping process
   defp map(enum, mod, fun) when is_function(fun, 2) do
     Enum.map(enum, &(fun.(mod, &1)))
@@ -58,148 +93,148 @@ defmodule PropCheck.Instrument do
   # Helper function for mapping expressions
   defp map_expr(enum, mod), do: map(enum, mod, &instrument_expr/2)
 
-  @doc "Instruments the form of a module"
-  def instrument_form(mod, {:abstract_code, {:raw_abstract_v1, clauses}}) when is_list(clauses) do
-    instr_clauses = map(clauses, mod, &instrument_mod_clause/2)
+  @doc "Instruments the forms of a module"
+  def instrument_forms(instrumenter, {:abstract_code, {:raw_abstract_v1, clauses}}) when is_list(clauses) do
+    instr_clauses = map(clauses, instrumenter, &instrument_mod_clause/2)
     {:abstract_code,
       {:raw_abstract_v1,
         instr_clauses}}
   end
 
   @doc "Instruments the clauses of a module"
-  def instrument_mod_clause(mod, {:function, line, name, arg_count, body}) do
-    instr_body = map(body, mod, &instrument_body/2)
+  def instrument_mod_clause(instrumenter, {:function, line, name, arg_count, body}) do
+    instr_body = map(body, instrumenter, &instrument_body/2)
     {:function, line, name, arg_count, instr_body}
   end
-  def instrument_mod_clause(_mod, clause), do: clause
+  def instrument_mod_clause(_instrumenter, clause), do: clause
 
   @doc "Instruments the each body (a `:clause`) of a function"
-  def instrument_body(mod, {:clause, line, args, local_vars, exprs}) do
-    instr_exprs = map_expr(exprs, mod)
+  def instrument_body(instrumenter, {:clause, line, args, local_vars, exprs}) do
+    instr_exprs = map_expr(exprs, instrumenter)
     {:clause, line, args, local_vars, instr_exprs}
   end
 
   @doc "This is a big switch over all kinds of expressions for instrumenting them"
-  def instrument_expr(_mod, {:atom, _, _} = a), do: a
-  def instrument_expr(mod, {:bc, line, expr, qs}) do
-    {:bc, line, instrument_expr(mod, expr), map(qs, mod, &instrument_qualifier/2)}
+  def instrument_expr(_instrumenter, {:atom, _, _} = a), do: a
+  def instrument_expr(instrumenter, {:bc, line, expr, qs}) do
+    {:bc, line, instrument_expr(instrumenter, expr), map(qs, instrumenter, &instrument_qualifier/2)}
   end
-  def instrument_expr(mod, {:bin, line, bin_elements}) do
-    {:bin, line, map(bin_elements, mod, &instrument_bin_element/2)}
+  def instrument_expr(instrumenter, {:bin, line, bin_elements}) do
+    {:bin, line, map(bin_elements, instrumenter, &instrument_bin_element/2)}
   end
-  def instrument_expr(mod, {:block, line, exprs}) do
-    {:block, line, map_expr(exprs, mod)}
+  def instrument_expr(instrumenter, {:block, line, exprs}) do
+    {:block, line, map_expr(exprs, instrumenter)}
   end
-  def instrument_expr(mod, {:case, line, expr, clauses}) do
-    instr_expr = instrument_expr(mod, expr)
-    {:case, line, instr_expr, map(clauses, mod, &instrument_clause/2)}
+  def instrument_expr(instrumenter, {:case, line, expr, clauses}) do
+    instr_expr = instrument_expr(instrumenter, expr)
+    {:case, line, instr_expr, map(clauses, instrumenter, &instrument_clause/2)}
   end
-  def instrument_expr(mod, {:catch, line, expr}), do: {:catch, line, instrument_expr(mod, expr)}
-  def instrument_expr(mod, {:cons, line, e1, e2}), do: {:cons, line, instrument_expr(mod, e1), instrument_expr(mod, e2)}
-  def instrument_expr(mod, {:fun, line, cs}) when is_list(cs) do
-    {:fun, line, map(cs, mod, &instrument_clause/2)}
+  def instrument_expr(instrumenter, {:catch, line, expr}), do: {:catch, line, instrument_expr(instrumenter, expr)}
+  def instrument_expr(instrumenter, {:cons, line, e1, e2}), do: {:cons, line, instrument_expr(instrumenter, e1), instrument_expr(instrumenter, e2)}
+  def instrument_expr(instrumenter, {:fun, line, cs}) when is_list(cs) do
+    {:fun, line, map(cs, instrumenter, &instrument_clause/2)}
   end
-  def instrument_expr(_mod, {:fun, _, _} = f), do: f
-  def instrument_expr(mod, {:call, _l, {:remote, _m, _f}, _args} = c), do: instrument_function_call(mod, c)
-  def instrument_expr(mod, {:call, _l, _f, _args} = c), do: instrument_function_call(mod, c)
-  def instrument_expr(mod, {:if, line, cs}), do: {:if, line, map(cs, mod, &instrument_clause/2)}
-  def instrument_expr(mod, {:lc, line, e, qs}) do
-    {:lc, line, instrument_expr(mod, e), map(qs, mod, &instrument_qualifier/2)}
+  def instrument_expr(_instrumenter, {:fun, _, _} = f), do: f
+  def instrument_expr(instrumenter, {:call, _l, {:remote, _m, _f}, _args} = c), do: instrument_function_call(instrumenter, c)
+  def instrument_expr(instrumenter, {:call, _l, _f, _args} = c), do: instrument_function_call(instrumenter, c)
+  def instrument_expr(instrumenter, {:if, line, cs}), do: {:if, line, map(cs, instrumenter, &instrument_clause/2)}
+  def instrument_expr(instrumenter, {:lc, line, e, qs}) do
+    {:lc, line, instrument_expr(instrumenter, e), map(qs, instrumenter, &instrument_qualifier/2)}
   end
-  def instrument_expr(mod, {:map, line, assocs}), do: {:map, line, map(assocs, mod,  &instrument_assoc/2)}
-  def instrument_expr(mod, {:map, line, expr, assocs}) do
-    {:map, line, instrument_expr(mod, expr), map(assocs, mod, &instrument_assoc/2)}
+  def instrument_expr(instrumenter, {:map, line, assocs}), do: {:map, line, map(assocs, instrumenter,  &instrument_assoc/2)}
+  def instrument_expr(instrumenter, {:map, line, expr, assocs}) do
+    {:map, line, instrument_expr(instrumenter, expr), map(assocs, instrumenter, &instrument_assoc/2)}
   end
-  def instrument_expr(mod, {:match, line, p, e}) do
-    {:match, line, instrument_pattern(mod, p), instrument_expr(mod, e)}
+  def instrument_expr(instrumenter, {:match, line, p, e}) do
+    {:match, line, instrument_pattern(instrumenter, p), instrument_expr(instrumenter, e)}
   end
-  def instrument_expr(_mod, {:nil, line}), do: {:nil, line}
-  def instrument_expr(mod, {:op, line, op, e1}), do: {:op, line, op, instrument_expr(mod, e1)}
-  def instrument_expr(mod, {:op, line, op, e1, e2}), do:
-    {:op, line, op, instrument_expr(mod, e1), instrument_expr(mod, e2)}
-  def instrument_expr(mod, {:receive, _line, _cs} = r), do: instrument_receive(mod, r)
-  def instrument_expr(mod, {:receive, _line, _cs, _e, _b} = r), do: instrument_receive(mod, r)
-  def instrument_expr(mod, {:record, line, name, fields}) do # record creation
-    {:record, line, name, map_expr(fields, mod)}
+  def instrument_expr(_instrumenter, {:nil, line}), do: {:nil, line}
+  def instrument_expr(instrumenter, {:op, line, op, e1}), do: {:op, line, op, instrument_expr(instrumenter, e1)}
+  def instrument_expr(instrumenter, {:op, line, op, e1, e2}), do:
+    {:op, line, op, instrument_expr(instrumenter, e1), instrument_expr(instrumenter, e2)}
+  def instrument_expr(instrumenter, {:receive, _line, _cs} = r), do: instrument_receive(instrumenter, r)
+  def instrument_expr(instrumenter, {:receive, _line, _cs, _e, _b} = r), do: instrument_receive(instrumenter, r)
+  def instrument_expr(instrumenter, {:record, line, name, fields}) do # record creation
+    {:record, line, name, map_expr(fields, instrumenter)}
   end
-  def instrument_expr(mod, {:record, line, e, name, fields}) do # record update
-    {:record, line, instrument_expr(mod, e), name, map_expr(fields, mod)}
+  def instrument_expr(instrumenter, {:record, line, e, name, fields}) do # record update
+    {:record, line, instrument_expr(instrumenter, e), name, map_expr(fields, instrumenter)}
   end
-  def instrument_expr(mod, {:record_field, line, field, expr}), do: {:record, line, field, instrument_expr(mod, expr)}
-  def instrument_expr(mod, {:record_field, line, expr, name, field}), do:
-    {:record, line, instrument_expr(mod, expr), name, field}
-  def instrument_expr(_mod, {:record_index, _line, _name, _fields} = r), do: r
-  def instrument_expr(mod, {:tuple, line, es}), do: {:tuple, line, map_expr(es, mod)}
-  def instrument_expr(mod, {:try, line, body, cases, catches, expr}) do
-    i_body = map_expr(body, mod)
-    i_cases = map(cases, mod, &instrument_clause/2)
-    i_catches = map(catches, mod, &instrument_clause/2)
-    {:try, line, i_body, i_cases, i_catches, instrument_expr(mod, expr)}
+  def instrument_expr(instrumenter, {:record_field, line, field, expr}), do: {:record, line, field, instrument_expr(instrumenter, expr)}
+  def instrument_expr(instrumenter, {:record_field, line, expr, name, field}), do:
+    {:record, line, instrument_expr(instrumenter, expr), name, field}
+  def instrument_expr(_instrumenter, {:record_index, _line, _name, _fields} = r), do: r
+  def instrument_expr(instrumenter, {:tuple, line, es}), do: {:tuple, line, map_expr(es, instrumenter)}
+  def instrument_expr(instrumenter, {:try, line, body, cases, catches, expr}) do
+    i_body = map_expr(body, instrumenter)
+    i_cases = map(cases, instrumenter, &instrument_clause/2)
+    i_catches = map(catches, instrumenter, &instrument_clause/2)
+    {:try, line, i_body, i_cases, i_catches, instrument_expr(instrumenter, expr)}
   end
-  def instrument_expr(_mod, {:var, _l, _name} = v), do: v
-  def instrument_expr(_mod, {literal, _line, _val} = l) when literal in [:atom, :integer, :float, :char, :string], do: l
+  def instrument_expr(_instrumenter, {:var, _l, _name} = v), do: v
+  def instrument_expr(_instrumenter, {literal, _line, _val} = l) when literal in [:atom, :integer, :float, :char, :string], do: l
 
   @doc "Instrument a part of binary pattern definition"
-  def instrument_bin_element(mod, {:bin_element, line, expr, size, tsl}) do
-    {:bin_element, line, instrument_expr(mod, expr), size, tsl}
+  def instrument_bin_element(instrumenter, {:bin_element, line, expr, size, tsl}) do
+    {:bin_element, line, instrument_expr(instrumenter, expr), size, tsl}
   end
 
   @doc "Instrument case, catch, function clauses"
-  def instrument_clause(mod, {:clause, line, p, body}) do
-    {:clause, line, instrument_pattern(mod, p), map_expr(body, mod)}
+  def instrument_clause(instrumenter, {:clause, line, p, body}) do
+    {:clause, line, instrument_pattern(instrumenter, p), map_expr(body, instrumenter)}
   end
-  # def instrument_clause(mod, {:clause, line, ps, body}) when is_list(ps) do
-  #   {:clause, line, map_expr(ps, mod), map_expr(body, mod)}
+  # def instrument_clause(instrumenter, {:clause, line, ps, body}) when is_list(ps) do
+  #   {:clause, line, map_expr(ps, instrumenter), map_expr(body, instrumenter)}
   # end
-  def instrument_clause(mod, {:clause, line, ps, [guards], body}) when is_list(ps) and is_list(guards) do
-    {:clause, line, map_expr(ps, mod), [map_expr(guards, mod)], map_expr(body, mod)}
+  def instrument_clause(instrumenter, {:clause, line, ps, [guards], body}) when is_list(ps) and is_list(guards) do
+    {:clause, line, map_expr(ps, instrumenter), [map_expr(guards, instrumenter)], map_expr(body, instrumenter)}
   end
-  def instrument_clause(mod, {:clause, line, ps, guards, body}) when is_list(ps) do
-    {:clause, line, map_expr(ps, mod), map_expr(guards, mod), map_expr(body, mod)}
+  def instrument_clause(instrumenter, {:clause, line, ps, guards, body}) when is_list(ps) do
+    {:clause, line, map_expr(ps, instrumenter), map_expr(guards, instrumenter), map_expr(body, instrumenter)}
   end
 
   @doc "Instrument qualifiers of list and bit comprehensions"
-  def instrument_qualifier(mod, {:generate, line, p, e}), do: {:generate, line, instrument_pattern(mod, p), instrument_expr(mod, e)}
-  def instrument_qualifier(mod, {:b_generate, line, p, e}), do: {:b_generate, line, instrument_pattern(mod, p), instrument_expr(mod, e)}
-  def instrument_qualifier(mod, e), do: instrument_expr(mod, e)
+  def instrument_qualifier(instrumenter, {:generate, line, p, e}), do: {:generate, line, instrument_pattern(instrumenter, p), instrument_expr(instrumenter, e)}
+  def instrument_qualifier(instrumenter, {:b_generate, line, p, e}), do: {:b_generate, line, instrument_pattern(instrumenter, p), instrument_expr(instrumenter, e)}
+  def instrument_qualifier(instrumenter, e), do: instrument_expr(instrumenter, e)
 
   @doc "Instrument patterns, which are mostly expressions, except for variables/atoms"
-  # def instrument_pattern(mod, {x, p, s}), do: {x, instrument_expr(mod, p), s}
-  def instrument_pattern(mod, ps) when is_list(ps), do: map(ps, mod, &instrument_pattern/2)
-  def instrument_pattern(mod, p), do: instrument_expr(mod, p)
+  # def instrument_pattern(instrumenter, {x, p, s}), do: {x, instrument_expr(instrumenter, p), s}
+  def instrument_pattern(instrumenter, ps) when is_list(ps), do: map(ps, instrumenter, &instrument_pattern/2)
+  def instrument_pattern(instrumenter, p), do: instrument_expr(instrumenter, p)
 
-  def instrument_assoc(mod, {assoc, line, key, value}) do
-    {assoc, line, instrument_expr(mod, key), instrument_expr(mod, value)}
+  def instrument_assoc(instrumenter, {assoc, line, key, value}) do
+    {assoc, line, instrument_expr(instrumenter, key), instrument_expr(instrumenter, value)}
   end
 
   @doc """
-  Instruments a function call and gives control the handler module `mod`.
+  Instruments a function call and gives control the handler module `instrumenter`.
   For now, we only instrumenting a call, if it is any of the interesting functions,
   i.e those might be a source of concurrency problems due to a shared mutable
   state or otherwise tinkering with scheduling.
   """
-  def instrument_function_call(mod, {:call, line, {:remote, line2, m, f}, as}) do
-    module = instrument_expr(mod, m)
-    fun = instrument_expr(mod, f)
-    args = map_expr(as, mod)
-    case instrumentable_function(m, f) do
-      true -> mod.handle_function_call({:call, line, {:remote, line2, module, fun}, args})
+  def instrument_function_call(instrumenter, {:call, line, {:remote, line2, m, f}, as}) do
+    module = instrument_expr(instrumenter, m)
+    fun = instrument_expr(instrumenter, f)
+    args = map_expr(as, instrumenter)
+    case instrumenter.is_instrumentable_function(m, f) do
+      true -> instrumenter.handle_function_call({:call, line, {:remote, line2, module, fun}, args})
       _ -> {:call, line, {:remote, line2, module, fun}, args}
     end
   end
-  def instrument_function_call(mod, {:call, line, f, as}) do
-    fun = instrument_expr(mod, f)
-    args = map_expr(as, mod)
+  def instrument_function_call(instrumenter, {:call, line, f, as}) do
+    fun = instrument_expr(instrumenter, f)
+    args = map_expr(as, instrumenter)
     {:call, line, fun, args}
   end
 
   @doc "The receive might be handled differently, therefore it has its own function"
-  def instrument_receive(mod, {:receive, line, cs}) do
-    {:receive, line, map(cs, mod, &instrument_clause/2)}
+  def instrument_receive(instrumenter, {:receive, line, cs}) do
+    {:receive, line, map(cs, instrumenter, &instrument_clause/2)}
   end
-  def instrument_receive(mod, {:receive, line, cs, e, b})  do
-    {:receive, line, map(cs, mod, &instrument_clause/2),
-      instrument_expr(mod, e), map_expr(b, mod)}
+  def instrument_receive(instrumenter, {:receive, line, cs, e, b})  do
+    {:receive, line, map(cs, instrumenter, &instrument_clause/2),
+      instrument_expr(instrumenter, e), map_expr(b, instrumenter)}
   end
 
   @doc """

--- a/lib/instrument.ex
+++ b/lib/instrument.ex
@@ -19,6 +19,13 @@ defmodule PropCheck.Instrument do
   """
   @callback is_instrumentable_function(mod ::module, fun :: atom) :: boolean
 
+  def instrument_app(app, instrumenter) do
+    case  Application.spec(app, :modules) do
+      mods when is_list(mods) -> Enum.each(mods, &(instrument_module(&1, instrumenter)))
+      nil -> :ok
+    end
+  end
+
   @doc """
   Takes the object code of the module, instruments it and update the module
   in the code server with instrumented byte code.

--- a/lib/instrument.ex
+++ b/lib/instrument.ex
@@ -5,6 +5,13 @@ defmodule PropCheck.Instrument do
   """
 
   @doc """
+  Handle the instrumentation of a (remote) function call. Must return a
+  valid expression in Erlang Abstract Form.
+  """
+  @callback handle_function_call(call :: any) :: any
+
+
+  @doc """
   Takes the object code of the module, instruments it and update the module
   in the code server with instrumented byte code.
   """
@@ -24,128 +31,138 @@ defmodule PropCheck.Instrument do
   module as found in the code server.
   """
   def get_forms_of_module(mod) when is_atom(mod) do
-    {^mod, filename, beam_code} = :code.get_object_code(mod)
+    {^mod, _filename, beam_code} = :code.get_object_code(mod)
     case :beam_lib.chunks(beam_code, [:abstract_code]) do
       {:ok, {^mod, [forms]}} -> {:ok, forms}
       error -> error
     end
   end
 
+  def map(enum, mod, fun) when is_function(fun, 2) do
+    Enum.map(enum, &(fun.(mod, &1)))
+  end
+  def map_expr(enum, mod), do: map(enum, mod, &instrument_expr/2)
+
   @doc "Instruments the form of a module"
-  def instrument_form({:abstract_code, {:raw_abstract_v1, clauses}}) when is_list(clauses) do
-    instr_clauses = Enum.map(clauses, &instrument_mod_clause/1)
+  def instrument_form(mod, {:abstract_code, {:raw_abstract_v1, clauses}}) when is_list(clauses) do
+    instr_clauses = map(clauses, mod, &instrument_mod_clause/2)
     {:abstract_form,
       {:raw_abstract_v1,
         instr_clauses}}
   end
 
   @doc "Instruments the clauses of a module"
-  def instrument_mod_clause({:function, line, name, arg_count, body}) do
-    instr_body = Enum.map(body, &instrument_body/1)
-    {:function, line, name, arg_count, body}
+  def instrument_mod_clause(mod, {:function, line, name, arg_count, body}) do
+    instr_body = map(body, mod, &instrument_body/2)
+    {:function, line, name, arg_count, instr_body}
   end
-  def instrument_mod_clause(clause), do: clause
+  def instrument_mod_clause(_mod, clause), do: clause
 
   @doc "Instruments the each body (a `:clause`) of a function"
-  def instrument_body({:clause, line, args, local_vars, exprs}) do
-    instr_exprs = Enum.map(exprs, &instrument_expr/1)
+  def instrument_body(mod, {:clause, line, args, local_vars, exprs}) do
+    instr_exprs = map_expr(exprs, mod)
     {:clause, line, args, local_vars, instr_exprs}
   end
 
   @doc "This is a big switch over all kinds of expressions for instrumenting them"
-  def instrument_expr({:atom, _, _} = a), do: a
-  def instrument_expr({:bc, line, expr, qs}) do
-    {:bc, line, instrument_expr(expr), Enum.map(qs, &instrument_qualifier/1)}
+  def instrument_expr(_mod, {:atom, _, _} = a), do: a
+  def instrument_expr(mod, {:bc, line, expr, qs}) do
+    {:bc, line, instrument_expr(mod, expr), map(qs, mod, &instrument_qualifier/2)}
   end
-  def instrument_expr({:bin, line, bin_elements}) do
-    {:bin, line, Enum.map(bin_elements, &instrument_bin_element/1)}
+  def instrument_expr(mod, {:bin, line, bin_elements}) do
+    {:bin, line, map(bin_elements, mod, &instrument_bin_element/2)}
   end
-  def instrument_expr({:block, line, exprs}) do
-    {:block, line, Enum.map(exprs, &instrument_expr/1)}
+  def instrument_expr(mod, {:block, line, exprs}) do
+    {:block, line, map(exprs, mod, &instrument_expr/2)}
   end
-  def instrument_expr({:case, line, expr, clauses}) do
-    instr_expr = instrument_expr(expr)
-    {:case, line, instr_expr, Enum.map(clauses, &instrument_clause/1)}
+  def instrument_expr(mod, {:case, line, expr, clauses}) do
+    instr_expr = instrument_expr(mod, expr)
+    {:case, line, instr_expr, map(clauses, mod, &instrument_clause/2)}
   end
-  def instrument_expr({:catch, line, expr}), do: {:catch, line, instrument_expr(expr)}
-  def instrument_expr({:cons, line, e1, e2}), do: {:cons, line, instrument_expr(e1), instrument_expr(e2)}
-  def instrument_expr({:fun, line, cs}) when is_list(cs) do
-    {:fun, line, Enum.map(cs, &instrument_clause/1)}
+  def instrument_expr(mod, {:catch, line, expr}), do: {:catch, line, instrument_expr(mod, expr)}
+  def instrument_expr(mod, {:cons, line, e1, e2}), do: {:cons, line, instrument_expr(mod, e1), instrument_expr(mod, e2)}
+  def instrument_expr(mod, {:fun, line, cs}) when is_list(cs) do
+    {:fun, line, map(cs, mod, &instrument_clause/2)}
   end
-  def instrument_expr({:fun, _, _} = f), do: f
-  def instrument_expr({:call, _l, _f, _args} = c), do: instrument_function_call(c)
-  def instrument_expr({:remote, _l, _m, _f, _args} = c), do: instrument_function_call(c)
-  def instrument_expr({:if, line, cs}), do: {:if, line, Enum.map(cs, &instrument_clause/1)}
-  def instrument_expr({:lc, line, e, qs}) do
-    {:lc, line, instrument_expr(e), Enum.map(qs, &instrument_qualifier/1)}
+  def instrument_expr(_mod, {:fun, _, _} = f), do: f
+  def instrument_expr(mod, {:call, _l, _f, _args} = c), do: instrument_function_call(mod, c)
+  def instrument_expr(mod, {:call, _l, {:remote, _m, _f}, _args} = c), do: instrument_function_call(mod, c)
+  def instrument_expr(mod, {:if, line, cs}), do: {:if, line, map(cs, mod, &instrument_clause/2)}
+  def instrument_expr(mod, {:lc, line, e, qs}) do
+    {:lc, line, instrument_expr(mod, e), map(qs, mod, &instrument_qualifier/2)}
   end
-  def instrument_expr({:map, line, assocs}), do: {:map, line, Enum.map(assocs, &instrument_assoc/1)}
-  def instrument_expr({:map, line, expr, assocs}) do
-    {:map, line, instrument_expr(expr), Enum.map(assocs, &instrument_assoc/1)}
+  def instrument_expr(mod, {:map, line, assocs}), do: {:map, line, map(assocs, mod,  &instrument_assoc/2)}
+  def instrument_expr(mod, {:map, line, expr, assocs}) do
+    {:map, line, instrument_expr(mod, expr), map(assocs, mod, &instrument_assoc/2)}
   end
-  def instrument_expr({:match, line, p, e}) do
-    {:match, line, instrument_pattern(p), instrument_expr(e)}
+  def instrument_expr(mod, {:match, line, p, e}) do
+    {:match, line, instrument_pattern(mod, p), instrument_expr(mod, e)}
   end
-  def instrument_expr({:nil, line}), do: {:nil, line}
-  def instrument_expr({:op, line, op, e1}), do: {:op, line, op, instrument_expr(e1)}
-  def instrument_expr({:op, line, op, e1, e2}), do: {:op, line, op, instrument_expr(e1), instrument_expr(e2)}
-  def instrument_expr({:receive, line, cs} = r), do: instrument_receive(r)
-  def instrument_expr({:receive, line, cs, e, b} = r), do: instrument_receive(r)
-  def instrument_expr({:record, line, name, fields}) do # record creation
-    {:record, line, name, Enum.map(fields, &instrument_expr/1)}
+  def instrument_expr(_mod, {:nil, line}), do: {:nil, line}
+  def instrument_expr(mod, {:op, line, op, e1}), do: {:op, line, op, instrument_expr(mod, e1)}
+  def instrument_expr(mod, {:op, line, op, e1, e2}), do:
+    {:op, line, op, instrument_expr(mod, e1), instrument_expr(mod, e2)}
+  def instrument_expr(mod, {:receive, _line, _cs} = r), do: instrument_receive(mod, r)
+  def instrument_expr(mod, {:receive, _line, _cs, _e, _b} = r), do: instrument_receive(mod, r)
+  def instrument_expr(mod, {:record, line, name, fields}) do # record creation
+    {:record, line, name, map_expr(fields, mod)}
   end
-  def instrument_expr({:record, line, e, name, fields}) do # record update
-    {:record, line, instrument_expr(e), name, Enum.map(fields, &instrument_expr/1)}
+  def instrument_expr(mod, {:record, line, e, name, fields}) do # record update
+    {:record, line, instrument_expr(mod, e), name, map_expr(fields, mod)}
   end
-  def instrument_expr({:record_field, line, field, expr}), do: {:record, line, field, instrument_expr(expr)}
-  def instrument_expr({:record_field, line, expr, name, field}), do: {:record, line, instrument_expr(expr), name, field}
-  def instrument_expr({:record_index, line, _name, _fields} = r), do: r
-  def instrument_expr({:tuple, line, es}), do: {:tuple, line, Enum.map(es, &instrument_expr/1)}
-  def instrument_expr({:try, line, body, cases, catches, expr}) do
-    i_body = Enum.map(body, &instrument_expr/1)
-    i_cases = Enum.map(cases, &instrument_clause/1)
-    i_catches = Enum.map(catches, &instrument_clause/1)
-    {:try, line, i_body, i_cases, i_catches, instrument_expr(expr)}
+  def instrument_expr(mod, {:record_field, line, field, expr}), do: {:record, line, field, instrument_expr(mod, expr)}
+  def instrument_expr(mod, {:record_field, line, expr, name, field}), do:
+    {:record, line, instrument_expr(mod, expr), name, field}
+  def instrument_expr(_mod, {:record_index, _line, _name, _fields} = r), do: r
+  def instrument_expr(mod, {:tuple, line, es}), do: {:tuple, line, map_expr(es, mod)}
+  def instrument_expr(mod, {:try, line, body, cases, catches, expr}) do
+    i_body = map_expr(body, mod)
+    i_cases = map(cases, mod, &instrument_clause/2)
+    i_catches = map(catches, mod, &instrument_clause/2)
+    {:try, line, i_body, i_cases, i_catches, instrument_expr(mod, expr)}
   end
-  def instrument_expr({:var, _l, _name} = v), do: v
-  def instrument_expr({literal, _line, _val} = l) when literal in [:atom, :integer, :float, :char, :string], do: l
+  def instrument_expr(_mod, {:var, _l, _name} = v), do: v
+  def instrument_expr(_mod, {literal, _line, _val} = l) when literal in [:atom, :integer, :float, :char, :string], do: l
 
-
-  def instrument_bin_element({:bin_element, line, expr, size, tsl}) do
-    {:bin_element, line, instrument_expr(expr), size, tsl}
+  @doc "Instrument a part of binary pattern definition"
+  def instrument_bin_element(mod, {:bin_element, line, expr, size, tsl}) do
+    {:bin_element, line, instrument_expr(mod, expr), size, tsl}
   end
 
   @doc "Instrument case, catch, function clauses"
-  def instrument_clause({:clause, line, p, body}) do
-    {:clause, line, instrument_pattern(p), Enum.map(body, &instrument_expr/1)}
+  def instrument_clause(mod, {:clause, line, p, body}) do
+    {:clause, line, instrument_pattern(mod, p), map_expr(body, mod)}
   end
-  def instrument_clause({:clause, line, p, guards, body}) do
-    {:clause, line, instrument_pattern(p), Enum.map(guards, &instrument_expr/1), Enum.map(body, &instrument_expr/1)}
+  def instrument_clause(mod, {:clause, line, ps, [guards], body}) when is_list(ps) do
+    {:clause, line, map_expr(ps, mod), [map_expr(guards, mod)], map_expr(body, mod)}
+  end
+  def instrument_clause(mod, {:clause, line, ps, guards, body}) when is_list(ps) do
+    {:clause, line, map_expr(ps, mod), map_expr(guards, mod), map_expr(body, mod)}
   end
 
   @doc "Instrument qualifiers of list and bit comprehensions"
-  def instrument_qualifier({:generate, line, p, e}), do: {:generate, line, instrument_pattern(p), instrument_expr(e)}
-  def instrument_qualifier({:b_generate, line, p, e}), do: {:b_generate, line, instrument_pattern(p), instrument_expr(e)}
-  def instrument_qualifier(e), do: instrument_expr(e)
+  def instrument_qualifier(mod, {:generate, line, p, e}), do: {:generate, line, instrument_pattern(mod, p), instrument_expr(mod, e)}
+  def instrument_qualifier(mod, {:b_generate, line, p, e}), do: {:b_generate, line, instrument_pattern(mod, p), instrument_expr(mod, e)}
+  def instrument_qualifier(mod, e), do: instrument_expr(mod, e)
 
   @doc "Instrument patterns, which are mostly expressions, except for variables/atoms"
-  def instrument_pattern({x, p, s}), do: {x, instrument_expr(p), s}
-  def instrument_pattern(ps) when is_list(ps), do: Enum.map(ps, &instrument_pattern/1)
-  def instrument_pattern(p), do: instrument_expr(p)
+  # def instrument_pattern(mod, {x, p, s}), do: {x, instrument_expr(mod, p), s}
+  def instrument_pattern(mod, ps) when is_list(ps), do: map(ps, mod, &instrument_pattern/2)
+  def instrument_pattern(mod, p), do: instrument_expr(mod, p)
 
-  def instrument_assoc({assoc, line, key, value}) do
-    {assoc, line, instrument_expr(key), instrument_expr(value)}
+  def instrument_assoc(mod, {assoc, line, key, value}) do
+    {assoc, line, instrument_expr(mod, key), instrument_expr(mod, value)}
   end
 
-
-  def instrument_function_call(c), do: throw "Not Implemented"
+  def instrument_function_call(mod, c), do: mod.handle_function_call(c)
 
   @doc "The receive might be handled differently, therefore it has its own function"
-  def instrument_receive({:receive, line, cs} = r) do
-    {:receive, line, Enum.map(cs, &instrument_clause/1)}
+  def instrument_receive(mod, {:receive, line, cs}) do
+    {:receive, line, map(cs, mod, &instrument_clause/2)}
   end
-  def instrument_receive({:receive, line, cs, e, b} = r) do
-    {:receive, line, Enum.map(cs, &instrument_clause/1), instrument_expr(e), Enum.map(b, &instrument_expr/1)}
+  def instrument_receive(mod, {:receive, line, cs, e, b})  do
+    {:receive, line, map(cs, mod, &instrument_clause/2),
+      instrument_expr(mod, e), map_expr(b, mod)}
   end
 
 

--- a/mix.exs
+++ b/mix.exs
@@ -86,6 +86,7 @@ defmodule PropCheck.Mixfile do
         ex_unit
         iex
         mix
+        compiler
       )a,
       flags: ~w(
         error_handling

--- a/test/basic_types_test.exs
+++ b/test/basic_types_test.exs
@@ -1,4 +1,7 @@
 defmodule PropCheck.Test.BasicTypes do
+  @moduledoc """
+  Tests for the basic generators or types, Mostly delegated as doctest to `PropCheck.BasicTypes?.
+  """
   use ExUnit.Case, async: true
   use PropCheck, default_opts: &PropCheck.TestHelpers.config/0
   import PropCheck.TestHelpers, except: [config: 0]

--- a/test/counterstrike_test.exs
+++ b/test/counterstrike_test.exs
@@ -1,5 +1,8 @@
 defmodule PropCheck.Test.CounterStrikeTest do
 
+  @moduledoc """
+  Tests for the handling counter examples.
+  """
   use ExUnit.Case, async: true
   use PropCheck, default_opts: &PropCheck.TestHelpers.config/0
   import PropCheck.TestHelpers, except: [config: 0]

--- a/test/instrument_test.exs
+++ b/test/instrument_test.exs
@@ -106,11 +106,6 @@ defmodule PropCheck.Test.InstrumentTester do
 
   test "instrument an entire module" do
     mod = PropCheck.Support.InstrumentExample
-    # the following assert is only trued if we are not running cover-compiled
-    case :cover.is_compiled(mod) do
-      false -> assert :code.modified_modules() == []
-      _ -> :we_dont_know
-    end
 
     assert {:ok, ^mod, _module, []} = Instrument.instrument_module(mod, MessageInstrumenter)
     # This is robust even if wae are running cover compiled, but we cannot check wheather
@@ -128,6 +123,6 @@ defmodule PropCheck.Test.InstrumentTester do
     # This assertion should hold, but does not, because the custom attribute is not stored.
     # assert Instrument.is_instrumented?(forms)  == {:attribute, 1, :instrumented, PropCheck}
     assert Instrument.is_instrumented?(forms)  == false
-    Logger.debug(mod.module_info(:attributes))
+    Logger.debug(inspect mod.module_info(:attributes))
   end
 end

--- a/test/instrument_test.exs
+++ b/test/instrument_test.exs
@@ -1,0 +1,24 @@
+defmodule PropCheck.Test.InstrumentTester do
+  @moduledoc """
+  Tests the instrumentation functionalities
+  """
+
+  use ExUnit.Case
+
+  alias PropCheck.Instrument
+
+  test "Read the forms of the beam" do
+    assert {:ok, forms} = Instrument.get_forms_of_module(PropCheck.Support.InstrumentExample)
+    IO.inspect(forms, [pretty: true, limit: :infinity])
+    assert tuple_size(forms) == 2
+    {:abstract_code, code} = forms
+    assert tuple_size(code) == 2
+    {raw_abstract_v1, clauses} = code
+  end
+
+  test "Initial instrumentation is the identity" do
+    {:ok, forms} = Instrument.get_forms_of_module(PropCheck.Support.InstrumentExample)
+    instrumented_forms = Instrument.instrument_form(forms)
+  end
+
+end

--- a/test/instrument_test.exs
+++ b/test/instrument_test.exs
@@ -5,6 +5,7 @@ defmodule PropCheck.Test.InstrumentTester do
 
   use ExUnit.Case
   import ExUnit.CaptureLog
+  import ExUnit.CaptureIO
   alias PropCheck.Instrument
 
   defmodule Identity do
@@ -20,17 +21,40 @@ defmodule PropCheck.Test.InstrumentTester do
     end
   end
 
+  defmodule MessageInstrumenter do
+    @moduledoc """
+    Implements the Instrumentation as puts of `"Instrumented!" before calling the original function.
+    """
+    require Logger
+    @behaviour Instrument
+    @impl true
+    def handle_function_call(call) do
+      Logger.error("handle_function: #{inspect call}")
+      puts_msg = Instrument.encode_call({__MODULE__, :log_hello, ["instrumented!"]})
+      Instrument.prepend_call(call, puts_msg)
+    end
+
+    def log_hello(msg) do
+      Logger.info(msg)
+    end
+  end
+
   test "Read the forms of the beam" do
-    assert {:ok, forms} = Instrument.get_forms_of_module(PropCheck.Support.InstrumentExample)
+    mod = PropCheck.Support.InstrumentExample
+    assert {:ok, filename, forms} = Instrument.get_forms_of_module(mod)
     IO.inspect(forms, [pretty: true, limit: :infinity])
     assert tuple_size(forms) == 2
     {:abstract_code, code} = forms
     assert tuple_size(code) == 2
     assert {:raw_abstract_v1, clauses} = code
+
+    expected_path = Path.join(["_build", "test", "lib", "propcheck", "ebin"])
+    assert expected_path == Path.relative_to_cwd(filename) |> Path.dirname()
+    assert Atom.to_string(mod) <> ".beam" == Path.basename(filename)
   end
 
   test "Initial instrumentation is the identity" do
-    {:ok, forms} = Instrument.get_forms_of_module(PropCheck.Support.InstrumentExample)
+    {:ok, _file, forms} = Instrument.get_forms_of_module(PropCheck.Support.InstrumentExample)
     logs = capture_log fn ->
       instrumented_forms = Instrument.instrument_form(Identity, forms)
       assert forms == instrumented_forms
@@ -41,4 +65,42 @@ defmodule PropCheck.Test.InstrumentTester do
   test "instrumentable functions" do
     assert true == Instrument.instrumentable_function({:atom, 0, :gen_server}, {:atom, 0, :start_link})
   end
+
+  test "compile the retrieved forms" do
+    mod = PropCheck.Support.InstrumentExampleSimple
+    {:ok, filename, forms} = Instrument.get_forms_of_module(mod)
+    compile_result = Instrument.compile_module(mod, filename, forms)
+
+    assert {:ok, ^mod, _module, []} = compile_result
+  end
+
+  test "prepending a call" do
+    mod = PropCheck.Support.InstrumentExampleSimple
+    output = capture_io fn -> mod.hello() end
+    assert output =~ "Hello"
+
+    {:ok, filename, forms} = Instrument.get_forms_of_module(mod)
+    altered_forms = Instrument.instrument_form(MessageInstrumenter, forms)
+
+    assert altered_forms != forms
+
+    compile_result = Instrument.compile_module(mod, filename, altered_forms)
+    assert {:ok, ^mod, _module, []} = compile_result
+
+    # This assertion might break if before this test another instrumentation happens
+    mods = :code.modified_modules()
+    assert [mod] == mods
+
+    {:ok, ^mod, _module, []} = compile_result
+    log_output = capture_log fn -> mod.hello() end
+    assert log_output =~ "instrumented!"
+    # assert log_output =~ "Hello"
+  end
+
+  test "instrument an entire module" # do
+  #   mod = PropCheck.Support.InstrumentExample
+  #   # Idea: 1 Validate that no yields are available [how? how to recurse over the structure]
+  #   #       2 instrument the code
+  #   #       3 check that yield is inside the module now
+  # end
 end

--- a/test/instrument_test.exs
+++ b/test/instrument_test.exs
@@ -125,4 +125,17 @@ defmodule PropCheck.Test.InstrumentTester do
     assert Instrument.is_instrumented?(forms)  == false
     Logger.debug(inspect mod.module_info(:attributes))
   end
+
+  test "instrument an entire application" do
+    Logger.error "All Apps: #{inspect Application.loaded_applications()}"
+    # The ASN1 compiler is not really used, so no damage is expected
+    app = :asn1
+    all_modules = Application.spec(app, :modules)
+    Enum.each(all_modules, fn m -> assert not Instrument.is_instrumented?(m) end)
+
+    assert :ok == Instrument.instrument_app(app, MessageInstrumenter)
+
+    Enum.each(all_modules, fn m -> assert Instrument.is_instrumented?(m) end)
+
+  end
 end

--- a/test/instrument_test.exs
+++ b/test/instrument_test.exs
@@ -4,16 +4,20 @@ defmodule PropCheck.Test.InstrumentTester do
   """
 
   use ExUnit.Case
-
+  import ExUnit.CaptureLog
   alias PropCheck.Instrument
 
   defmodule Identity do
     @moduledoc """
     Implements the Instrumentation as the identity function
     """
+    require Logger
     @behaviour Instrument
     @impl true
-    def handle_function_call(call), do: IO.inspect(call)
+    def handle_function_call(call) do
+      Logger.error("handle_function: #{inspect call}")
+      call
+    end
   end
 
   test "Read the forms of the beam" do
@@ -22,12 +26,19 @@ defmodule PropCheck.Test.InstrumentTester do
     assert tuple_size(forms) == 2
     {:abstract_code, code} = forms
     assert tuple_size(code) == 2
-    {raw_abstract_v1, clauses} = code
+    assert {:raw_abstract_v1, clauses} = code
   end
 
   test "Initial instrumentation is the identity" do
     {:ok, forms} = Instrument.get_forms_of_module(PropCheck.Support.InstrumentExample)
-    instrumented_forms = Instrument.instrument_form(Identity, forms)
+    logs = capture_log fn ->
+      instrumented_forms = Instrument.instrument_form(Identity, forms)
+      assert forms == instrumented_forms
+    end
+    assert logs =~ "handle_function:"
   end
 
+  test "instrumentable functions" do
+    assert true == Instrument.instrumentable_function({:atom, 0, :gen_server}, {:atom, 0, :start_link})
+  end
 end

--- a/test/instrument_test.exs
+++ b/test/instrument_test.exs
@@ -7,6 +7,15 @@ defmodule PropCheck.Test.InstrumentTester do
 
   alias PropCheck.Instrument
 
+  defmodule Identity do
+    @moduledoc """
+    Implements the Instrumentation as the identity function
+    """
+    @behaviour Instrument
+    @impl true
+    def handle_function_call(call), do: IO.inspect(call)
+  end
+
   test "Read the forms of the beam" do
     assert {:ok, forms} = Instrument.get_forms_of_module(PropCheck.Support.InstrumentExample)
     IO.inspect(forms, [pretty: true, limit: :infinity])
@@ -18,7 +27,7 @@ defmodule PropCheck.Test.InstrumentTester do
 
   test "Initial instrumentation is the identity" do
     {:ok, forms} = Instrument.get_forms_of_module(PropCheck.Support.InstrumentExample)
-    instrumented_forms = Instrument.instrument_form(forms)
+    instrumented_forms = Instrument.instrument_form(Identity, forms)
   end
 
 end

--- a/test/let_test.exs
+++ b/test/let_test.exs
@@ -1,4 +1,7 @@
 defmodule PropCheck.Test.LetAndShrinks do
+  @moduledoc """
+  Tests for shrinking and let definitions
+  """
   use ExUnit.Case, async: true
   use PropCheck, default_opts: &PropCheck.TestHelpers.config/0
   import PropCheck.TestHelpers, except: [config: 0]

--- a/test/level_tpbt_test.exs
+++ b/test/level_tpbt_test.exs
@@ -1,4 +1,7 @@
 defmodule PropCheck.Test.LevelTest do
+  @moduledoc """
+  Tests for targeted properties.
+  """
   use PropCheck, default_opts: &PropCheck.TestHelpers.config/0
   use ExUnit.Case, async: true
   import PropCheck.TestHelpers, except: [config: 0]

--- a/test/pingpong_test.exs
+++ b/test/pingpong_test.exs
@@ -1,5 +1,8 @@
 defmodule PropCheck.Test.PingPongTest do
 
+  @moduledoc """
+  A test for a strange call sequence, which once troubled us.
+  """
   use ExUnit.Case, async: false
   use PropCheck
 

--- a/test/propcheck_test.exs
+++ b/test/propcheck_test.exs
@@ -1,4 +1,7 @@
 defmodule PropcheckTest do
+  @moduledoc """
+  Basic Tests for PropCheck, delegating mostly to doc tests.
+  """
   use ExUnit.Case, async: true
   use PropCheck, default_opts: &PropCheck.TestHelpers.config/0
   import PropCheck.TestHelpers, except: [config: 0]

--- a/test/properties_default_opts_function.exs
+++ b/test/properties_default_opts_function.exs
@@ -1,4 +1,7 @@
 defmodule PropertiesDefaultOptsFunctionTest do
+  @moduledoc """
+  A Test for property options.
+  """
   alias PropCheck.Test
   use ExUnit.Case, async: true
   use PropCheck, default_opts: &DefaultOpts.config/0

--- a/test/properties_test.exs
+++ b/test/properties_test.exs
@@ -1,4 +1,7 @@
 defmodule PropertiesTest do
+  @moduledoc """
+  Tests for setup and options
+  """
   use ExUnit.Case, async: true
   use PropCheck, default_opts: [numtests: 1]
 

--- a/test/stack_test.exs
+++ b/test/stack_test.exs
@@ -1,4 +1,7 @@
 defmodule PropCheck.StackTypeTest do
+  @moduledoc """
+  A simple test for a simple stack.
+  """
   use ExUnit.Case, async: true
   use PropCheck, default_opts: &PropCheck.TestHelpers.config/0
   import PropCheck.TestHelpers, except: [config: 0]

--- a/test/statem_modeldsl_pretty_reports_test.exs
+++ b/test/statem_modeldsl_pretty_reports_test.exs
@@ -1,4 +1,7 @@
 defmodule PropCheck.Test.PrettyReportsDSL do
+  @moduledoc """
+  Tests for reporting the DSL models
+  """
   use PropCheck
   use PropCheck.StateM.ModelDSL
   use ExUnit.Case

--- a/test/statem_pretty_reports_test.exs
+++ b/test/statem_pretty_reports_test.exs
@@ -1,4 +1,7 @@
 defmodule PropCheck.Test.PrettyReports do
+  @moduledoc """
+  Tests for the pretty reporter.
+  """
   use PropCheck
   use PropCheck.StateM
   use ExUnit.Case

--- a/test/store_counter_examples_test.exs
+++ b/test/store_counter_examples_test.exs
@@ -4,6 +4,7 @@
 # we can verify that no test here resulted in a stored counter example.
 #
 defmodule StoreCounterExample.ModuleTag do
+  @moduledoc "A test for stroring counter examples"
   use ExUnit.Case
   use PropCheck
   @moduletag store_counter_example: false, manual: true
@@ -17,6 +18,7 @@ defmodule StoreCounterExample.ModuleTag do
 end
 
 defmodule StoreCounterExample.DescribeTag do
+  @moduledoc "A test for stroring counter examples"
   use ExUnit.Case
   use PropCheck
 
@@ -35,6 +37,7 @@ defmodule StoreCounterExample.DescribeTag do
 end
 
 defmodule StoreCounter.ExampleTag do
+  @moduledoc "A test for stroring counter examples"
   use ExUnit.Case
   use PropCheck
 

--- a/test/support/instrument_example.ex
+++ b/test/support/instrument_example.ex
@@ -24,7 +24,7 @@ defmodule PropCheck.Support.InstrumentExample do
       [] -> "empty list"
       [1, 2, 3] -> "three values"
       l when is_list(l) -> "a value list"
-      v -> "a single value"
+      _v -> "a single value"
     end
   end
 

--- a/test/support/instrument_example.ex
+++ b/test/support/instrument_example.ex
@@ -8,6 +8,8 @@ defmodule PropCheck.Support.InstrumentExample do
     private_hello(s)
   end
 
+  def hello, do: IO.puts "Hello"
+
   def fetch_from_ets(table, key) do
     [x] = :ets.lookup_element(table, key, 1)
     x
@@ -20,6 +22,7 @@ defmodule PropCheck.Support.InstrumentExample do
   def ets_in_expr(table, key) do
     case :ets.lookup_element(table, key, 1) do
       [] -> "empty list"
+      [1, 2, 3] -> "three values"
       l when is_list(l) -> "a value list"
       v -> "a single value"
     end

--- a/test/support/instrument_example.ex
+++ b/test/support/instrument_example.ex
@@ -1,0 +1,31 @@
+defmodule PropCheck.Support.InstrumentExample do
+
+  @moduledoc """
+  A module for instrumentation.
+  """
+  def hello(s) when is_binary(s) do
+    IO.puts "Hello to #{s}"
+    private_hello(s)
+  end
+
+  def fetch_from_ets(table, key) do
+    [x] = :ets.lookup_element(table, key, 1)
+    x
+  end
+
+  def put_to_ets(table, key, value) do
+    :ets.update_element(table, key, value)
+  end
+
+  def ets_in_expr(table, key) do
+    case :ets.lookup_element(table, key, 1) do
+      [] -> "empty list"
+      l when is_list(l) -> "a value list"
+      v -> "a single value"
+    end
+  end
+
+  defp private_hello(s) do
+    IO.puts "Private Hello to #{s}"
+  end
+end

--- a/test/support/instrument_example_simple.ex
+++ b/test/support/instrument_example_simple.ex
@@ -1,0 +1,8 @@
+defmodule PropCheck.Support.InstrumentExampleSimple do
+
+  @moduledoc """
+  A module for instrumentation.
+  """
+  def hello, do: IO.puts "Hello"
+
+end

--- a/test/tree_test.exs
+++ b/test/tree_test.exs
@@ -1,4 +1,7 @@
 defmodule PropCheck.TreeTest do
+  @moduledoc """
+  A set of properties for various tree implementations
+  """
   use ExUnit.Case, async: true
   alias PropCheck.Test.Tree
   use PropCheck, default_opts: &PropCheck.TestHelpers.config/0

--- a/test/verify_counter_examples_test.exs
+++ b/test/verify_counter_examples_test.exs
@@ -1,6 +1,8 @@
 defmodule VerifyCounterExampleTest do
-  # The tests here verify that CheckCounterExamplesTest did indeed not store
-  # any counter examples.
+  @moduledoc """
+  The tests here verify that CheckCounterExamplesTest did indeed not store
+  any counter examples.
+  """
   use ExUnit.Case
   use PropCheck, default_opts: &PropCheck.TestHelpers.config/0
 

--- a/test/verify_exception_detection_test.exs
+++ b/test/verify_exception_detection_test.exs
@@ -1,5 +1,5 @@
 defmodule VerifyExceptionDetectionTest do
-  # Tests to check that exception detection works as intended.
+  @moduledoc "Tests to check that exception detection works as intended."
   use ExUnit.Case
   use PropCheck
 

--- a/test/verify_verbose_elixir_syntax_test.exs
+++ b/test/verify_verbose_elixir_syntax_test.exs
@@ -1,4 +1,7 @@
 defmodule VerifyVerboseElixirSyntaxTest do
+  @moduledoc """
+  Verifies the verbose syntax
+  """
   use ExUnit.Case, async: false
   use PropCheck, default_opts: [:verbose]
 

--- a/test/verify_verbose_test.exs
+++ b/test/verify_verbose_test.exs
@@ -1,5 +1,5 @@
 defmodule VerifyVerbose do
-  # Check that setting verboseness using PROPCHECK_VERBOSE works as intended.
+  @moduledoc "Check that setting verboseness using PROPCHECK_VERBOSE works as intended."
   use ExUnit.Case
   use PropCheck
 


### PR DESCRIPTION
This PR adds instrumentation to PropCheck. It is helpful for parallel testing, since in practice we need to sprinkle `:erlang.yield()` over the place to provoke different runs by the otherwise to deterministic scheduler. 

At the same time, we need such a facility for more complex means, e.g our own scheduler working in the spirit of PULSE for EQC. 