### PR TITLE
Build matrix and Caching

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -71,7 +71,7 @@ jobs:
         id: cache-plts
         uses: actions/cache@v1
         with:
-          path: ~/.mix
+          path: _build/dev
           key: ${{ env.ELIXIR_VERSION }}-plt
       - name: Check Credo
         run: mix credo --strict

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -26,15 +26,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup elixir
-      uses: actions/setup-elixir@v1
-      with:
-        elixir-version: 1.9.4 # Define the elixir version [required]
-        otp-version: 22.2 # Define the OTP version [required]
-    - name: Install Dependencies
-      run: env MIX_ENV=TEST mix do deps.get, deps.compile
-    - name: Compile PropCheck
-      run: env MIX_ENV=TEST mix compile --warnings-as-errors
-    - name: Run Tests
-      run: PROPCHECK_DEBUG=1 PROPCHECK_VERBOSE=1 PROPCHECK_NUMTESTS=200 PROPCHECK_SEARCH_STEPS=1000 mix tests --cover --trace
+      - uses: actions/checkout@v2
+      - name: Setup elixir
+        uses: actions/setup-elixir@v1
+        with:
+          elixir-version: 1.9.4 # Define the elixir version [required]
+          otp-version: 22.2 # Define the OTP version [required]
+      - name: Install Dependencies
+        run: env MIX_ENV=TEST mix do deps.get, deps.compile
+      - name: Compile PropCheck
+        run: env MIX_ENV=TEST mix compile --warnings-as-errors
+      - name: Run Tests
+        run: PROPCHECK_DEBUG=1 PROPCHECK_VERBOSE=1 PROPCHECK_NUMTESTS=200 PROPCHECK_SEARCH_STEPS=1000 mix tests --cover --trace

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -7,7 +7,8 @@ on:
     branches: [ master ]
 
 jobs:
-  lint:
+  # Build the dialyzer core PLT and dependency caches early.
+  lint_caches:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -22,18 +23,37 @@ jobs:
         with:
           path: deps
           key: ${{ hashFiles('**/mix.lock') }}-deps
-      - name: Get Dependencies
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: mix deps.get
+      - name: Cache Core PLTs
+        id: cache-core-plts
+        uses: actions/cache@v1
+        with:
+          path: ~/.mix
+          key: 1.9.4-core-plt
+      - name: Build Core PLTs
+        if: steps.cache-core-plts.outputs.cache-hit != 'true'
+        run: mix dialyzer --plt
+  lint:
+    needs: lint_caches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup elixir
+        uses: actions/setup-elixir@v1
+        with:
+          elixir-version: 1.9.4 # Define the elixir version [required] - must equal the dialyzer cache key
+          otp-version: 22.2 # Define the OTP version [required]
+      - name: Cache Dependencies
+        id: cache-deps
+        uses: actions/cache@v1
+        with:
+          path: deps
+          key: ${{ hashFiles('**/mix.lock') }}-deps
       - name: Cache Core PLTs
         id: cache-core-plts
         uses: actions/cache@v1
         with:
           path: ~/.mix
           key: 1.9.4-plt
-      - name: Build Core PLTs
-        if: steps.cache-core-plts.outputs.cache-hit != 'true'
-        run: mix dialyzer --plt
       - name: Check Credo
         run: mix credo --strict
       - name: Run the Dialyzer

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -7,8 +7,22 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup elixir
+        uses: actions/setup-elixir@v1
+        with:
+          elixir-version: 1.9.4 # Define the elixir version [required]
+          otp-version: 22.2 # Define the OTP version [required]
+      - name: Install Dependencies
+        run: env MIX_ENV=TEST mix do deps.get, deps.compile
+      - name: Check Credo
+        run: mix credo --strict
+      - name: Run the Dialyzer
+        run: env MIX_ENV=test mix dialyzer
+  test:
     runs-on: ubuntu-latest
 
     steps:
@@ -24,7 +38,3 @@ jobs:
       run: env MIX_ENV=TEST mix compile --warnings-as-errors
     - name: Run Tests
       run: PROPCHECK_DEBUG=1 PROPCHECK_VERBOSE=1 PROPCHECK_NUMTESTS=200 PROPCHECK_SEARCH_STEPS=1000 mix tests --cover --trace
-    - name: Check Credo
-      run: mix credo --strict
-    - name: Run the Dialyzer
-      run: env MIX_ENV=test mix dialyzer

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -22,24 +22,42 @@ jobs:
         with:
           path: deps
           key: ${{ hashFiles('**/mix.lock') }}-deps
+      - name: Get Dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: mix deps.get
       - name: Cache Core PLTs
         id: cache-core-plts
         uses: actions/cache@v1
         with:
           path: ~/.mix
           key: 1.9.4-plt
-      - name: Get Dependencies
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: mix deps.get
-      - name: Check Credo
-        run: mix credo --strict
       - name: Build Core PLTs
         if: steps.cache-core-plts.outputs.cache-hit != 'true'
         run: mix dialyzer --plt
+      - name: Check Credo
+        run: mix credo --strict
       - name: Run the Dialyzer
         run: env MIX_ENV=test mix dialyzer
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pair:
+          - erlang: 22.x
+            elixir: "1.10.1"
+          - erlang: 22.x
+            elixir: 1.9
+          - erlang: 22.x
+            elixir: 1.8
+          - erlang: 22.x
+            elixir: 1.7
+
+          - erlang: 21.x
+            elixir: 1.9
+          - erlang: 21.x
+            elixir: 1.8
+          - erlang: 21.x
+            elixir: 1.7
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -43,7 +43,7 @@ jobs:
           path: _build/dev
           key: ${{ hashFiles('**/mix.lock') }}-plt
       - name: Build PLTs
-        if: steps.cache-core-plts.outputs.cache-hit != 'true' || steps.cache-core-plts.outputs.cache-hit != 'true'
+        if: steps.cache-core-plts.outputs.cache-hit != 'true' || steps.cache-plts.outputs.cache-hit != 'true'
         run: mix dialyzer --plt
   lint:
     needs: lint_caches

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           path: deps
           key: ${{ hashFiles('**/mix.lock') }}-deps
+      - name: Get Dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: mix deps.get
       - name: Cache Core PLTs
         id: cache-core-plts
         uses: actions/cache@v1

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  ELIXIR_VERSION: 1.9.4
+  OTP_VERSION: 22.2
+
 jobs:
   # Build the dialyzer core PLT and dependency caches early.
   lint_caches:
@@ -15,8 +19,8 @@ jobs:
       - name: Setup elixir
         uses: actions/setup-elixir@v1
         with:
-          elixir-version: 1.9.4 # Define the elixir version [required] - must equal the dialyzer cache key
-          otp-version: 22.2 # Define the OTP version [required]
+          elixir-version: ${{ env.ELIXIR_VERSION }} # Define the elixir version [required]
+          otp-version: ${{ env.OTP_VERSION }} # Define the OTP version [required]
       - name: Cache Dependencies
         id: cache-deps
         uses: actions/cache@v1
@@ -28,7 +32,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.mix
-          key: 1.9.4-core-plt
+          key: ${{ env.ELIXIR_VERSION }}-core-plt
       - name: Build Core PLTs
         if: steps.cache-core-plts.outputs.cache-hit != 'true'
         run: mix dialyzer --plt
@@ -40,8 +44,8 @@ jobs:
       - name: Setup elixir
         uses: actions/setup-elixir@v1
         with:
-          elixir-version: 1.9.4 # Define the elixir version [required] - must equal the dialyzer cache key
-          otp-version: 22.2 # Define the OTP version [required]
+          elixir-version: ${{ env.ELIXIR_VERSION }} # Define the elixir version [required]
+          otp-version: ${{ env.OTP_VERSION }} # Define the OTP version [required]
       - name: Cache Dependencies
         id: cache-deps
         uses: actions/cache@v1
@@ -53,7 +57,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.mix
-          key: 1.9.4-plt
+          key: ${{ env.ELIXIR_VERSION }}-plt
       - name: Check Credo
         run: mix credo --strict
       - name: Run the Dialyzer

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: _build/dev
-          key: ${{ env.ELIXIR_VERSION }}-plt
+          key: ${{ hashFiles('**/mix.lock') }}-plt
       - name: Build PLTs
         if: steps.cache-core-plts.outputs.cache-hit != 'true' || steps.cache-core-plts.outputs.cache-hit != 'true'
         run: mix dialyzer --plt
@@ -72,7 +72,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: _build/dev
-          key: ${{ env.ELIXIR_VERSION }}-plt
+          key: ${{ hashFiles('**/mix.lock') }}-plt
       - name: Check Credo
         run: mix credo --strict
       - name: Run the Dialyzer

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -33,8 +33,14 @@ jobs:
         with:
           path: ~/.mix
           key: ${{ env.ELIXIR_VERSION }}-core-plt
-      - name: Build Core PLTs
-        if: steps.cache-core-plts.outputs.cache-hit != 'true'
+      - name: Cache PLTs
+        id: cache-plts
+        uses: actions/cache@v1
+        with:
+          path: _build/dev
+          key: ${{ env.ELIXIR_VERSION }}-plt
+      - name: Build PLTs
+        if: steps.cache-core-plts.outputs.cache-hit != 'true' || steps.cache-core-plts.outputs.cache-hit != 'true'
         run: mix dialyzer --plt
   lint:
     needs: lint_caches
@@ -54,6 +60,12 @@ jobs:
           key: ${{ hashFiles('**/mix.lock') }}-deps
       - name: Cache Core PLTs
         id: cache-core-plts
+        uses: actions/cache@v1
+        with:
+          path: ~/.mix
+          key: ${{ env.ELIXIR_VERSION }}-core-plt
+      - name: Cache PLTs
+        id: cache-plts
         uses: actions/cache@v1
         with:
           path: ~/.mix

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -16,8 +16,15 @@ jobs:
         with:
           elixir-version: 1.9.4 # Define the elixir version [required]
           otp-version: 22.2 # Define the OTP version [required]
-      - name: Install Dependencies
-        run: env MIX_ENV=TEST mix do deps.get, deps.compile
+      - name: Cache Dependencies
+        id: cache-deps
+        uses: actions/cache@v1
+        with:
+          path: deps
+          key: ${{ hashFiles('**/mix.lock') }}-deps
+      - name: Get Dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: mix deps.get
       - name: Check Credo
         run: mix credo --strict
       - name: Run the Dialyzer
@@ -32,6 +39,15 @@ jobs:
         with:
           elixir-version: 1.9.4 # Define the elixir version [required]
           otp-version: 22.2 # Define the OTP version [required]
+      - name: Cache Dependencies
+        id: cache-deps
+        uses: actions/cache@v1
+        with:
+          path: deps
+          key: ${{ hashFiles('**/mix.lock') }}-deps
+      - name: Get Dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: mix deps.get
       - name: Install Dependencies
         run: env MIX_ENV=TEST mix do deps.get, deps.compile
       - name: Compile PropCheck

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: _build/dev
-          key: ${{ hashFiles('**/mix.lock') }}-plt
+          key: ${{ hashFiles('**/mix.lock') }}-all-plts
       - name: Build PLTs
         if: steps.cache-core-plts.outputs.cache-hit != 'true' || steps.cache-plts.outputs.cache-hit != 'true'
         run: mix dialyzer --plt
@@ -72,7 +72,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: _build/dev
-          key: ${{ hashFiles('**/mix.lock') }}-plt
+          key: ${{ hashFiles('**/mix.lock') }}-all-plts
       - name: Check Credo
         run: mix credo --strict
       - name: Run the Dialyzer

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup elixir
         uses: actions/setup-elixir@v1
         with:
-          elixir-version: 1.9.4 # Define the elixir version [required]
+          elixir-version: 1.9.4 # Define the elixir version [required] - must equal the dialyzer cache key
           otp-version: 22.2 # Define the OTP version [required]
       - name: Cache Dependencies
         id: cache-deps
@@ -22,11 +22,20 @@ jobs:
         with:
           path: deps
           key: ${{ hashFiles('**/mix.lock') }}-deps
+      - name: Cache Core PLTs
+        id: cache-core-plts
+        uses: actions/cache@v1
+        with:
+          path: ~/.mix
+          key: 1.9.4-plt
       - name: Get Dependencies
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: mix deps.get
       - name: Check Credo
         run: mix credo --strict
+      - name: Build Core PLTs
+        if: steps.cache-core-plts.outputs.cache-hit != 'true'
+        run: mix dialyzer --plt
       - name: Run the Dialyzer
         run: env MIX_ENV=test mix dialyzer
   test:


### PR DESCRIPTION
This pull request extends the github actions configuration to

* include a build matrix for multiple versions of Elixir and OTP
* cache dependencies
* cache dialyzer's PLTs in `~/.mix/` and `_build/dev`

Alas, we cannot only cache the PLTs from `_build/dev`, the github cache action requires that a directory is to be cached. We will see if this breaks something.

Fix #163.