### PR TITLE
Fix function clause error

### DIFF
--- a/lib/statem/reporter.ex
+++ b/lib/statem/reporter.ex
@@ -305,6 +305,7 @@ defmodule PropCheck.StateM.Reporter do
     Enum.map(cmds, &pretty_cmd_name(&1, opts))
   end
 
+  def pretty_cmd_name([tuple], opts), do: pretty_cmd_name(tuple, opts)
   def pretty_cmd_name({:init, data}, _opts), do: "init call -> #{inspect data, pretty: true}"
   def pretty_cmd_name({:set, {:var, n}, {:call, mod, fun, args}}, opts) do
     aliases = Keyword.get(opts, :alias, [mod])


### PR DESCRIPTION
I ran into the following error when reporting on failures in a test:

```
  1) property does not raise any exceptions (DeviceTracker.DevicesPropertyTest)
     test/device_tracker/devices_property_test.exs:18
     ** (FunctionClauseError) no function clause matching in PropCheck.StateM.Reporter.pretty_cmd_name/2

     The following arguments were given to PropCheck.StateM.Reporter.pretty_cmd_name/2:
     
         # 1
         [{:set, {:var, 18}, {:call, DeviceTracker.DevicesPropertyTest, :delete, ["6حˀW𐀻0攰1ʛ查ࡷ𐀺1"]}}]
     
         # 2
         [syntax_colors: []]
     
     Attempted function clauses (showing 2 out of 2):
     
         def pretty_cmd_name({:init, data}, _opts)
         def pretty_cmd_name({:set, {:var, n}, {:call, mod, fun, args}}, opts)
     
     code: property "does not raise any exceptions", numtests: 100, constraint_tries: 100 do
     stacktrace:
       (propcheck 1.2.1) lib/statem/reporter.ex:308: PropCheck.StateM.Reporter.pretty_cmd_name/2
       (propcheck 1.2.1) lib/statem/reporter.ex:222: PropCheck.StateM.Reporter.pretty_print_counter_example_cmd/1
       (propcheck 1.2.1) lib/properties.ex:246: PropCheck.Properties.handle_check_results/2
       test/device_tracker/devices_property_test.exs:18: (test)
```

This fixes that error.