### PR TITLE
Elixir 1.11: :iex should be listed in :extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,8 @@ defmodule PropCheck.Mixfile do
   # Type `mix help compile.app` for more information
   def application do
     [applications: [:logger, :proper, :libgraph],
-     mod: {PropCheck.App, []}]
+     mod: {PropCheck.App, []},
+     extra_applications: [:iex]]
   end
 
   # Specifies which paths to compile per environment


### PR DESCRIPTION
The warning was:
```
warning: IEx.Config.color/1 defined in application :iex is used by the current application but the current application does not directly depend on :iex. To fix this, you must do one of:

  1. If :iex is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :iex is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :iex, you may optionally skip this warning by adding [xref: [exclude: IEx.Config] to your "def project" in mix.exs

  lib/statem/reporter.ex:385: PropCheck.StateM.Reporter.syntax_colors/0
```