### PR TITLE
Use __STACKTRACE__ macro rather than the deprecated System.stacktrace()

### DIFF
--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -429,20 +429,17 @@ defmodule PropCheck do
               unquote(prop)
             rescue
               e in ExUnit.AssertionError ->
-                stacktrace = System.stacktrace
                 if verbose? do
                   e |> ExUnit.AssertionError.message() |> IO.write()
-                  formatted = Exception.format_stacktrace(stacktrace)
+                  formatted = Exception.format_stacktrace(__STACKTRACE__)
                   IO.puts("stacktrace:\n#{formatted}")
                 end
                 false
               e ->
-                stacktrace = System.stacktrace
-
                 if detect_exceptions? do
                   output = """
                   PropCheck detected an error:
-                  #{Exception.format(:error, e, stacktrace)}
+                  #{Exception.format(:error, e, __STACKTRACE__)}
                   """
 
                   if output_agent != nil do
@@ -452,15 +449,13 @@ defmodule PropCheck do
                   end
                 end
 
-                reraise e, stacktrace
+                reraise e, __STACKTRACE__
             catch
               kind, exception ->
-                stacktrace = System.stacktrace
-
                 if detect_exceptions? do
                   output = """
                   PropCheck detected an exception:
-                  #{Exception.format(kind, exception, stacktrace)}
+                  #{Exception.format(kind, exception, __STACKTRACE__)}
                   """
 
                   if output_agent != nil do

--- a/lib/statem_dsl.ex
+++ b/lib/statem_dsl.ex
@@ -501,7 +501,7 @@ defmodule PropCheck.StateM.DSL do
           {:post_condition, result}
         end
       rescue exc ->
-        stacktrace = Exception.format_stacktrace(System.stacktrace())
+        stacktrace = Exception.format_stacktrace(__STACKTRACE__)
         log_error "Got exception: #{inspect(exc)}\nstacktrace: #{stacktrace}"
         {:exception, {exc, stacktrace}}
       catch

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule PropCheck.Mixfile do
   def project do
     [app: :propcheck,
      version: "1.2.3-dev",
-     elixir: "~> 1.5",
+     elixir: "~> 1.7",
      elixirc_paths: elixirc_paths(Mix.env),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
Starting with Elixir 1.11, using procheck generates many warnings:
```
warning: System.stacktrace/0 is deprecated, use __STACKTRACE__ instead
```

Requires Elixir 1.7 as minimal version.