### PR TITLE
Update proper library, Fix OTP/23 issue

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -67,8 +67,8 @@ jobs:
             otp: 22.3.4
           - elixir: 1.11.1
             otp: 22.3.4
-          - elixir: 1.11.1
-            otp: 23.1.1
+          - elixir: 1.11
+            otp: 23.1
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -67,6 +67,8 @@ jobs:
             otp: 22.3.4
           - elixir: 1.11.1
             otp: 22.3.4
+          - elixir: 1.11.1
+            otp: 23.1.1
 
     steps:
       - uses: actions/checkout@v2

--- a/lib/propcheck.ex
+++ b/lib/propcheck.ex
@@ -1064,7 +1064,7 @@ defmodule PropCheck do
     not the size of a test.
     """
     @spec numtests(pos_integer, outer_test) :: outer_test
-    def numtests(n, property), do: {:numtests, n, property}
+    def numtests(n, property), do: :proper.numtests(n, property)
 
     @doc """
     Specifies that we expect the property `property` to fail for some input.
@@ -1072,7 +1072,7 @@ defmodule PropCheck do
     The property will be considered failing if it passes all the tests.
     """
     @spec fails(outer_test) :: outer_test
-    def fails(property), do: {:fails, property}
+    def fails(property), do: :proper.fails(property)
 
     @doc """
     Specifies an output function `print` to be used by PropCheck for all output
@@ -1081,7 +1081,7 @@ defmodule PropCheck do
     This wrapper is equivalent to the `on_output` option.
     """
     @spec on_output(outer_test, output_fun) :: outer_test
-    def on_output(property, print), do: {:on_output, print, property}
+    def on_output(property, print), do: :proper.on_output(print, property)
 
     @doc """
     Specifies that test cases produced by this property should be
@@ -1121,7 +1121,7 @@ defmodule PropCheck do
     """
     @spec aggregate(test, stats_printer, sample) ::  test
     def aggregate(property, printer, sample), do:
-        {:sample, sample, printer, property}
+      :proper.aggregate(printer, sample, property)
 
     @doc """
     Same as `collect/2`, but can accept both a single category and a
@@ -1194,8 +1194,8 @@ defmodule PropCheck do
     If this property fails, each failing sub-property will be reported and saved
     inside the counterexample along with its tag.
     """
-    @spec conjunction([{atom, test}]) :: test()
-    def conjunction(sub_properties), do: {:conjunction, sub_properties}
+    @spec conjunction([{atom, test}]) :: test
+    def conjunction(sub_properties), do: :proper.conjunction(sub_properties)
 
     # Helper functions
 

--- a/lib/targeted.ex
+++ b/lib/targeted.ex
@@ -149,7 +149,7 @@ defmodule PropCheck.TargetedPBT do
   """
   defmacro maximize(fitness) do
     quote do
-      :proper_target.update_target_uvs(unquote(fitness), :inf)
+      :proper_target.update_uv(unquote(fitness), :inf)
     end
   end
   @doc """
@@ -158,7 +158,7 @@ defmodule PropCheck.TargetedPBT do
   """
   defmacro minimize(fitness) do
     quote do
-      :proper_target.update_target_uvs(- unquote(fitness), :inf)
+      :proper_target.update_uv(- unquote(fitness), :inf)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -78,7 +78,7 @@ defmodule PropCheck.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:proper, "~> 1.3"},
+      {:proper, "~> 1.3", github: "proper-testing/proper"},
       {:libgraph, "~> 0.13"},
       {:coverex, "~> 1.4", only: :test},
       {:credo, "~> 1.4", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -18,7 +18,7 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm", "17ef63abde837ad30680ea7f857dd9e7ced9476cdd7b0394432af4bfc241b960"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
-  "proper": {:git, "https://github.com/proper-testing/proper.git", "c4648c07ffeb8da51ba4129e04af0f1efb3705b4", []},
+  "proper": {:git, "https://github.com/proper-testing/proper.git", "d1959aef5b41c28ef1a41a575758929f115dbe06", []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm", "13104d7897e38ed7f044c4de953a6c28597d1c952075eb2e328bc6d6f2bfc496"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm", "1d1848c40487cdb0b30e8ed975e34e025860c02e419cb615d255849f3427439d"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -18,7 +18,7 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm", "17ef63abde837ad30680ea7f857dd9e7ced9476cdd7b0394432af4bfc241b960"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
-  "proper": {:hex, :proper, "1.3.0", "c1acd51c51da17a2fe91d7a6fc6a0c25a6a9849d8dc77093533109d1218d8457", [:make, :mix, :rebar3], [], "hexpm", "4aa192fccddd03fdbe50fef620be9d4d2f92635b54f55fb83aec185994403cbc"},
+  "proper": {:git, "https://github.com/proper-testing/proper.git", "c4648c07ffeb8da51ba4129e04af0f1efb3705b4", []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm", "13104d7897e38ed7f044c4de953a6c28597d1c952075eb2e328bc6d6f2bfc496"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm", "1d1848c40487cdb0b30e8ed975e34e025860c02e419cb615d255849f3427439d"},
 }

--- a/test/level_tpbt_test.exs
+++ b/test/level_tpbt_test.exs
@@ -91,7 +91,7 @@ defmodule PropCheck.Test.LevelTest do
   #                {exited, _Pos} -> false;
   #                Pos ->
   #                  case length(Path) > 500 of
-  #                    true -> proper_sa:reset(), true;
+  #                    true -> proper_target:reset(), true;
   #                    _ ->
   #                      UV = distance(Pos, Exit),
   #                      ?MINIMIZE(UV),
@@ -113,10 +113,10 @@ defmodule PropCheck.Test.LevelTest do
 
     forall_targeted path <- path_gen() do
       case Level.follow_path(entrance, path, level) do
-        {:exited, _} -> false
+        {:exited, _pos} -> false
         pos ->
           if length(path) > 500 do
-            :proper_sa.reset()
+            :proper_target.reset()
             true
           else
             uv = distance(pos, exit_pos)
@@ -137,7 +137,7 @@ defmodule PropCheck.Test.LevelTest do
   #                      {exited, _Pos} -> false;
   #                      Pos ->
   #                        case length(Path) > 2000 of
-  #                          true -> proper_sa:reset(), true;
+  #                          true -> proper_target:reset(), true;
   #                          _ ->
   #                            UV = distance(Pos, Exit),
   #                            ?MINIMIZE(UV),
@@ -157,7 +157,7 @@ defmodule PropCheck.Test.LevelTest do
           if length(path) > 2_000 do
             # reset the search because we assume that the path is
             # too long and we are caught in a local minimum.
-            :proper_sa.reset()
+            :proper_target.reset()
             true
           else
             uv = distance(pos, exit_pos)
@@ -208,7 +208,7 @@ defmodule PropCheck.Test.LevelTest do
           if length(path) > 2_000 do
             # reset the search because we assume that the path is
             # too long and we are caught in a local minimum.
-            :proper_sa.reset()
+            :proper_target.reset()
             false
           else
             # measure the distance to exit and search for a new

--- a/test/verify-verbose-in-elixir-syntax.sh
+++ b/test/verify-verbose-in-elixir-syntax.sh
@@ -11,6 +11,7 @@ elixir_syntax_output=$(PROPCHECK_VERBOSE=1 mix test --include manual --include w
 # linked process crashes
 expected1='A linked process died with reason: an exception was raised:'
 expected2='** (ArithmeticError) bad argument in arithmetic expression'
+# pass
 if ! echo "$elixir_syntax_output" | grep -FA1 "$expected1" | grep -qF "$expected2"; then
     echo >&2 "Crash report from linked process not found"
     echo >&2 "Output:"
@@ -20,6 +21,7 @@ fi
 
 # linked process kills it self
 expected='A linked process died with reason :killed.'
+# pass
 if ! echo "$elixir_syntax_output" | grep -qF "$expected"; then
     echo >&2 "Crash report from linked process not found"
     echo >&2 "Output:"
@@ -28,7 +30,11 @@ if ! echo "$elixir_syntax_output" | grep -qF "$expected"; then
 fi
 
 # collect prints Elixir syntax
-expected='100% %{test: VerifyVerboseElixirSyntaxTest}'
+# TODO fix & uncomment:
+# fails returned result - '*****% %{test: VerifyVerboseElixirSyntaxTest}'
+# previous result:
+# expected='100% %{test: VerifyVerboseElixirSyntaxTest}'
+expected='*****% %{test: VerifyVerboseElixirSyntaxTest}'
 if ! echo "$elixir_syntax_output" | grep -qF "$expected"; then
     echo >&2 "Collected categories not found"
     echo >&2 "Output:"
@@ -39,6 +45,7 @@ fi
 # exception was raised on test crash
 expected1='An exception was raised:'
 expected2='** (RuntimeError) test crash'
+# pass
 if ! echo "$elixir_syntax_output" | grep -FA1 "$expected1" | grep -qF "$expected2"; then
     echo >&2 "Raised exception on test crash not found"
     echo >&2 "Output:"
@@ -50,6 +57,7 @@ fi
 # exception was raised with stacktrace
 expected1='Stacktrace:'
 expected2='    test/verify_verbose_elixir_syntax_test.exs:'
+# pass
 if ! echo "$elixir_syntax_output" | grep -FA1 "$expected1" | grep -qF "$expected2"; then
     echo >&2 "Raised exception with stacktrace not found"
     echo >&2 "Output:"

--- a/test/verify-verbose-in-elixir-syntax.sh
+++ b/test/verify-verbose-in-elixir-syntax.sh
@@ -11,7 +11,6 @@ elixir_syntax_output=$(PROPCHECK_VERBOSE=1 mix test --include manual --include w
 # linked process crashes
 expected1='A linked process died with reason: an exception was raised:'
 expected2='** (ArithmeticError) bad argument in arithmetic expression'
-# pass
 if ! echo "$elixir_syntax_output" | grep -FA1 "$expected1" | grep -qF "$expected2"; then
     echo >&2 "Crash report from linked process not found"
     echo >&2 "Output:"
@@ -21,7 +20,6 @@ fi
 
 # linked process kills it self
 expected='A linked process died with reason :killed.'
-# pass
 if ! echo "$elixir_syntax_output" | grep -qF "$expected"; then
     echo >&2 "Crash report from linked process not found"
     echo >&2 "Output:"
@@ -30,11 +28,7 @@ if ! echo "$elixir_syntax_output" | grep -qF "$expected"; then
 fi
 
 # collect prints Elixir syntax
-# TODO fix & uncomment:
-# fails returned result - '*****% %{test: VerifyVerboseElixirSyntaxTest}'
-# previous result:
-# expected='100% %{test: VerifyVerboseElixirSyntaxTest}'
-expected='*****% %{test: VerifyVerboseElixirSyntaxTest}'
+expected='100.0% %{test: VerifyVerboseElixirSyntaxTest}'
 if ! echo "$elixir_syntax_output" | grep -qF "$expected"; then
     echo >&2 "Collected categories not found"
     echo >&2 "Output:"
@@ -45,7 +39,6 @@ fi
 # exception was raised on test crash
 expected1='An exception was raised:'
 expected2='** (RuntimeError) test crash'
-# pass
 if ! echo "$elixir_syntax_output" | grep -FA1 "$expected1" | grep -qF "$expected2"; then
     echo >&2 "Raised exception on test crash not found"
     echo >&2 "Output:"
@@ -57,7 +50,6 @@ fi
 # exception was raised with stacktrace
 expected1='Stacktrace:'
 expected2='    test/verify_verbose_elixir_syntax_test.exs:'
-# pass
 if ! echo "$elixir_syntax_output" | grep -FA1 "$expected1" | grep -qF "$expected2"; then
     echo >&2 "Raised exception with stacktrace not found"
     echo >&2 "Output:"

--- a/test/verify_verbose_elixir_syntax_test.exs
+++ b/test/verify_verbose_elixir_syntax_test.exs
@@ -30,8 +30,7 @@ defmodule VerifyVerboseElixirSyntaxTest do
   @tag :manual
   property "collect prints Elixir syntax" do
     forall _n <- nat() do
-      true
-      |> collect(%{test: __MODULE__})
+      collect(true, %{test: __MODULE__})
     end
   end
 


### PR DESCRIPTION
This is a WIP for updating the `:proper` to the latest version (from master as it was not released since 2018)

You can find more information on the issue page: https://github.com/alfert/propcheck/issues/180

TODO:
- [x] lint pass
- [x] test pass for all OTP versions
- [x] issue in PropEr fixed: [Pull Request](https://github.com/proper-testing/proper/pull/254)
- [x] test_ext pass for all OTP versions

