### PR TITLE
reduce the number of search steps to prevent test timeouts

### DIFF
--- a/test/targeted_tree_test.exs
+++ b/test/targeted_tree_test.exs
@@ -40,7 +40,7 @@ defmodule PropCheck.Test.TargetTreeTest do
     end
   end
 
-  property "A left-heavy tree" do
+  property "A left-heavy tree", [search_steps: 600] do
     forall_targeted t <- tree() do
       weight = sides(t)
       {left, right} = weight


### PR DESCRIPTION

This is related #196 and simply reduces the number of search steps. Hopefully, this simple measure is enough to prevent time outs during CI tests