### PR TITLE
Remove unused import from test

### DIFF
--- a/test/counterstrike_test.exs
+++ b/test/counterstrike_test.exs
@@ -5,7 +5,7 @@ defmodule PropCheck.Test.CounterStrikeTest do
   """
   use ExUnit.Case, async: true
   use PropCheck, default_opts: &PropCheck.TestHelpers.config/0
-  import PropCheck.TestHelpers, only: [debugln: 1, config: 0]
+  import PropCheck.TestHelpers, only: [debugln: 1]
   require Logger
 
   alias PropCheck.CounterStrike


### PR DESCRIPTION
See https://github.com/alfert/propcheck/pull/197/files, `import` of `config/0` is unused:

![image](https://user-images.githubusercontent.com/224554/116824041-4ebf6480-ab88-11eb-81d5-660e0e60fd20.png)
