### PR TITLE
Prep release 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Current Development
 * Using OTP 23 with stacktrace by depending on `:proper` from `:master`. Thanks to [@flowerett](https://github.com/flowerett)
+
+## 1.3.1
+* Configuration of counter example files for umbrella project. Thanks to [https://github.com/evnu](https://github.com/evnu)
 * Readme and mix optimisation. Thanks to [@kianmeng](https://github.com/kianmeng)
 ## 1.3.0
 * Upgrade to Elixir 1.7 as lowest Elixir version, since `get_stacktrace()` is deprecated in Elixir 1.11. Thanks to [@flowerett](https://github.com/flowerett)

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule PropCheck.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/alfert/propcheck"
-  @version "1.3.1-dev"
+  @version "1.3.1-rc1-dev"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -88,7 +88,9 @@ defmodule PropCheck.Mixfile do
 
   defp deps do
     [
-      {:proper, "~> 1.3", github: "proper-testing/proper"},
+      # This is the reference to proper on its github repo - instable.
+      # {:proper, "~> 1.3", github: "proper-testing/proper"},
+      {:proper, "~> 1.3"},
       {:libgraph, "~> 0.13"},
       {:coverex, "~> 1.4", only: :test},
       {:credo, "~> 1.4", only: [:dev, :test], runtime: false},

--- a/mix.exs
+++ b/mix.exs
@@ -89,8 +89,8 @@ defmodule PropCheck.Mixfile do
   defp deps do
     [
       # This is the reference to proper on its github repo - instable.
-      # {:proper, "~> 1.3", github: "proper-testing/proper"},
-      {:proper, "~> 1.3"},
+      {:proper, "~> 1.3", github: "proper-testing/proper"},
+      # {:proper, "~> 1.3"},
       {:libgraph, "~> 0.13"},
       {:coverex, "~> 1.4", only: :test},
       {:credo, "~> 1.4", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -19,7 +19,7 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm", "17ef63abde837ad30680ea7f857dd9e7ced9476cdd7b0394432af4bfc241b960"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
-  "proper": {:hex, :proper, "1.3.0", "c1acd51c51da17a2fe91d7a6fc6a0c25a6a9849d8dc77093533109d1218d8457", [:make, :mix, :rebar3], [], "hexpm", "4aa192fccddd03fdbe50fef620be9d4d2f92635b54f55fb83aec185994403cbc"},
+  "proper": {:git, "https://github.com/proper-testing/proper.git", "e3a12c478023ead2ce028fd9312c62a396456f03", []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm", "13104d7897e38ed7f044c4de953a6c28597d1c952075eb2e328bc6d6f2bfc496"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm", "1d1848c40487cdb0b30e8ed975e34e025860c02e419cb615d255849f3427439d"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -19,7 +19,7 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm", "17ef63abde837ad30680ea7f857dd9e7ced9476cdd7b0394432af4bfc241b960"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
-  "proper": {:git, "https://github.com/proper-testing/proper.git", "d1959aef5b41c28ef1a41a575758929f115dbe06", []},
+  "proper": {:hex, :proper, "1.3.0", "c1acd51c51da17a2fe91d7a6fc6a0c25a6a9849d8dc77093533109d1218d8457", [:make, :mix, :rebar3], [], "hexpm", "4aa192fccddd03fdbe50fef620be9d4d2f92635b54f55fb83aec185994403cbc"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm", "13104d7897e38ed7f044c4de953a6c28597d1c952075eb2e328bc6d6f2bfc496"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm", "1d1848c40487cdb0b30e8ed975e34e025860c02e419cb615d255849f3427439d"},
 }

--- a/release.sh
+++ b/release.sh
@@ -10,8 +10,8 @@
 # set -x
 
 # CONFIGURATION
-old="1.3.1"
-new="1.3.2"
+old="1.3.1-rc1"
+new="1.3.1"
 # do not set any variables beyond this line
 
 # check that old and new version differ


### PR DESCRIPTION
This PR prepare the 1.3.1-rc1 release. At first a 1.3.1 release was planned, but since the API from PropEr has changed since the last official release (1.3 in 2018), we stay at the current master branch. As a consequence, we do not release 1.3.1 but only the release candidate 1.3.1-rc1