### PR TITLE
Resolve counter examples in one source code location

### DIFF
--- a/lib/app.ex
+++ b/lib/app.ex
@@ -49,7 +49,7 @@ defmodule PropCheck.App do
 
   defp counter_example_file do
     case Application.get_env(:propcheck, :counter_examples) do
-      nil -> Mix.counter_example_file() || Mix.default_counter_examples_file()
+      nil -> Mix.counter_example_file_or_default()
       counter_example_file -> counter_example_file
     end
   end

--- a/lib/app.ex
+++ b/lib/app.ex
@@ -32,7 +32,7 @@ defmodule PropCheck.App do
   defp populate_application_env do
     Application.put_env(:propcheck, :global_verbose, global_verbose())
     Application.put_env(:propcheck, :global_detect_exceptions, global_detect_exceptions())
-    Application.put_env(:propcheck, :counter_example_file, counter_example_file())
+    Application.put_env(:propcheck, :counter_example_file, Mix.resolve_counter_examples_file())
   end
 
   defp global_verbose do
@@ -45,13 +45,6 @@ defmodule PropCheck.App do
     "PROPCHECK_DETECT_EXCEPTIONS"
     |> System.get_env()
     |> env_to_terniary()
-  end
-
-  defp counter_example_file do
-    case Application.get_env(:propcheck, :counter_examples) do
-      nil -> Mix.counter_example_file_or_default()
-      counter_example_file -> counter_example_file
-    end
   end
 
   defp env_to_terniary("1"), do: true

--- a/lib/mix.ex
+++ b/lib/mix.ex
@@ -10,6 +10,10 @@ defmodule PropCheck.Mix do
   def counter_example_file do
     get_in(Mix.Project.config(), [:propcheck, :counter_examples])
   end
+
+  def counter_example_file_or_default do
+    counter_example_file() || default_counter_examples_file()
+  end
 end
 
 defmodule Mix.Tasks.Propcheck do
@@ -49,7 +53,7 @@ defmodule Mix.Tasks.Propcheck do
 
     @doc false
     def run(_args) do
-      File.rm(PropCheck.Mix.counter_example_file())
+      PropCheck.Mix.counter_example_file_or_default() |> File.rm()
     end
   end
 

--- a/lib/mix.ex
+++ b/lib/mix.ex
@@ -1,18 +1,21 @@
 defmodule PropCheck.Mix do
   @moduledoc false
 
-  def default_counter_examples_file do
+  def resolve_counter_examples_file do
+    case Application.get_env(:propcheck, :counter_examples) do
+      nil -> counter_example_file() || default_counter_examples_file()
+      counter_example_file -> counter_example_file
+    end
+  end
+
+  defp default_counter_examples_file do
     Mix.Project.build_path()
     |> Path.dirname()
     |> Path.join("propcheck.ctex")
   end
 
-  def counter_example_file do
+  defp counter_example_file do
     get_in(Mix.Project.config(), [:propcheck, :counter_examples])
-  end
-
-  def counter_example_file_or_default do
-    counter_example_file() || default_counter_examples_file()
   end
 end
 
@@ -53,7 +56,7 @@ defmodule Mix.Tasks.Propcheck do
 
     @doc false
     def run(_args) do
-      PropCheck.Mix.counter_example_file_or_default() |> File.rm()
+      PropCheck.Mix.resolve_counter_examples_file() |> File.rm()
     end
   end
 
@@ -68,7 +71,7 @@ defmodule Mix.Tasks.Propcheck do
 
     @doc false
     def run(_args) do
-      filename = PropCheck.Mix.counter_example_file() |> String.to_charlist()
+      filename = PropCheck.Mix.resolve_counter_examples_file() |> String.to_charlist()
 
       case :dets.open_file(filename) do
         {:ok, ctx} ->


### PR DESCRIPTION
This pull request refactors resolving the location of the counter examples file. Previously, `mix propcheck.clean` differed slightly in how it resolved that file compared to `app.ex`. With this pull request, only one location determines where to look for counter examples (`Mix.PropCheck`).

Fix #205