### PR TITLE
Do not interpret [] as a command list

### DIFF
--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -295,6 +295,10 @@ defmodule PropCheck.Properties do
     end
   end
 
+  defp is_statem_commands([[]]) do
+    :data
+  end
+
   defp is_statem_commands([counter_example]) when is_list(counter_example) do
     is_command_list =
       counter_example


### PR DESCRIPTION
`is_statem_commands/1` interprets `[]` as a command list, but a command list should have at least a `:init` tuple. Due to this misinterpretation, an incorrect pretty printer is used, which results in a counter example of `[]` not being printed.

Fix #208 