### PR TITLE
Fix module name in deprecation warning

### DIFF
--- a/lib/statem_dsl.ex
+++ b/lib/statem_dsl.ex
@@ -1,7 +1,7 @@
 defmodule PropCheck.StateM.DSL do
   @moduledoc """
   _DEPRECATED_ : This module is deprecated, please use
-  `PropCheck.Statem.ModelDSL` instead.
+  `PropCheck.StateM.ModelDSL` instead.
 
   This module provides a shallow DSL (domain specific language) in Elixir
   for property based testing of stateful systems.


### PR DESCRIPTION
I was reading the docs and found that clicking the link in the deprecation warning for `PropCheck.StateM.DSL` didn't work. I believe this is because of a capitalization issue in the module name.