### PR TITLE
fix: correctly print counter-example for parallel execution

### DIFF
--- a/lib/properties.ex
+++ b/lib/properties.ex
@@ -290,8 +290,8 @@ defmodule PropCheck.Properties do
         for cmd <- cmds, do: Reporter.pretty_print_counter_example_cmd(cmd)
 
       :parallel_commands ->
-        [par_cmds] = counter_example
-        for par_cmd <- par_cmds, do: Reporter.pretty_print_counter_example_parallel(par_cmd)
+        [par_cmd] = counter_example
+        Reporter.pretty_print_counter_example_parallel(par_cmd)
     end
   end
 
@@ -320,6 +320,7 @@ defmodule PropCheck.Properties do
   defp is_statem_commands([{seq_commands, _par_commands}]) do
     case is_statem_commands([seq_commands]) do
       :commands -> :parallel_commands
+      :data -> :parallel_commands
       _ -> :data
     end
   end

--- a/lib/statem/reporter.ex
+++ b/lib/statem/reporter.ex
@@ -158,6 +158,9 @@ defmodule PropCheck.StateM.Reporter do
           remove_cmd = fn {_cmd, return} -> {nil, return} end
           [Enum.map(h1, remove_cmd), Enum.map(h2, remove_cmd)]
 
+        {:ok, []} ->
+          [[], []]
+
         :error ->
           [[], []]
       end

--- a/test/broken_ticket_issuer_test.exs
+++ b/test/broken_ticket_issuer_test.exs
@@ -15,13 +15,13 @@ defmodule PropCheck.Test.BrokenTicketIssuerTest do
     end
   end
 
-  def inc() do
+  def inc do
     x = Agent.get(Counter, & &1)
     Agent.update(Counter, fn _ -> x + 1 end)
     x
   end
 
-  def initial_state() do
+  def initial_state do
     0
   end
 

--- a/test/broken_ticket_issuer_test.exs
+++ b/test/broken_ticket_issuer_test.exs
@@ -1,0 +1,45 @@
+defmodule PropCheck.Test.BrokenTicketIssuerTest do
+  use ExUnit.Case, async: true
+  use PropCheck, default_opt: &PropCheck.TestHelpers.config/0
+  use PropCheck.StateM
+
+  @moduletag will_fail: true, manual: true
+
+  property "broken ticket issuer", [:verbose] do
+    forall cmds <- parallel_commands(__MODULE__) do
+      {:ok, pid} = Agent.start_link(fn -> 0 end)
+      Process.register(pid, Counter)
+      {_seq_history, _par_state, result} = run_parallel_commands(__MODULE__, cmds)
+      Agent.stop(pid)
+      result == :ok
+    end
+  end
+
+  def inc() do
+    x = Agent.get(Counter, & &1)
+    Agent.update(Counter, fn _ -> x + 1 end)
+    x
+  end
+
+  def initial_state() do
+    0
+  end
+
+  def command(_state) do
+    oneof([
+      {:call, __MODULE__, :inc, []}
+    ])
+  end
+
+  def next_state(state, _res, {:call, __MODULE__, :inc, []}) do
+    state + 1
+  end
+
+  def postcondition(state, {:call, __MODULE__, :inc, []}, res) do
+    state == res
+  end
+
+  def precondition(_state, {:call, __MODULE__, :inc, []}) do
+    true
+  end
+end

--- a/test/statem_pretty_reports_test.exs
+++ b/test/statem_pretty_reports_test.exs
@@ -686,6 +686,21 @@ defmodule PropCheck.Test.PrettyReports do
     end
   end
 
+  describe "parallel failures" do
+    test "empty parallel history" do
+      cmds = no_possible_interleaving_only_seq()
+
+      logs =
+        capture_io(fn ->
+          run_parallel_commands(__MODULE__, cmds) |> print_report(cmds)
+        end)
+
+      assert logs =~ "Sequential commands:"
+      assert logs =~ "var1"
+      assert logs =~ "Process 1:\n\n\nProcess 2:\n\n\n\n"
+    end
+  end
+
   #
   #
   # StateM implementation
@@ -821,6 +836,12 @@ defmodule PropCheck.Test.PrettyReports do
       {:set, {:var, 6}, {:call, __MODULE__, :noop, [4]}},
       {:set, {:var, 7}, {:call, __MODULE__, :noop, [5]}}
     ]
+
+  defp no_possible_interleaving_only_seq,
+    do:
+      {[
+         {:set, {:var, 1}, {:call, __MODULE__, :fail_postcond, []}}
+       ], [[], []]}
 
   defp strip_ansi_sequences(str) do
     r = ~r/\e\[.*?m/

--- a/test/verify_storing_counterexamples.sh
+++ b/test/verify_storing_counterexamples.sh
@@ -10,4 +10,21 @@ if [ $? -eq 0 ]; then
     exit 1
 fi
 
+# Verify that counterexamples for failing parallel tests are printed correctly
+out=$(mix test --include manual test/broken_ticket_issuer_test.exs --include will_fail:true)
+if [ $? -eq 0 ]; then
+    echo "$out" | cat
+    echo Test succeeded but should fail
+    exit 1
+else
+  if    ! grep -q "Counter-Example is:" <<< "$out" \
+     || ! grep -q "Sequential Start:"   <<< "$out" \
+     || ! grep -q "Parallel Process 1:" <<< "$out"; then
+    echo "$out" | cat
+    echo
+    echo Test did not print the counter example correctly
+    exit 1
+  fi
+fi
+
 mix test --include manual test/verify_counter_examples_test.exs

--- a/test/verify_storing_counterexamples.sh
+++ b/test/verify_storing_counterexamples.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Verify that we can configure storing counterexamples
 #

--- a/test/verify_storing_counterexamples.sh
+++ b/test/verify_storing_counterexamples.sh
@@ -10,6 +10,8 @@ if [ $? -eq 0 ]; then
     exit 1
 fi
 
+mix test --include manual test/verify_counter_examples_test.exs
+
 # Verify that counterexamples for failing parallel tests are printed correctly
 out=$(mix test --include manual test/broken_ticket_issuer_test.exs --include will_fail:true)
 if [ $? -eq 0 ]; then
@@ -26,5 +28,3 @@ else
     exit 1
   fi
 fi
-
-mix test --include manual test/verify_counter_examples_test.exs


### PR DESCRIPTION
When using parallel execution, the counter-example is a singleton list
with a single 2-tuple containing the sequential prefix and the
parallel executions.  But the code was expecting it to be an
enumerable.

```
  1) property broken ticket issuer (PropCheck.Test.BrokenTicketIssuerTest)
     test/broken_ticket_issuer_test.exs:8
     ** (Protocol.UndefinedError) protocol Enumerable not implemented for {[], [[{:set, {:var, 2}, {:call, PropCheck.Test.BrokenTicketIssuerTest, :inc, []}}, {:set, {:var, 3}, {:call, PropCheck.Test.BrokenTicketIssuerTest, :inc, []}}, {:set, {:var, 5}, {:call, PropCheck.Test.BrokenTicketIssuerTest, :inc, []}}], [{:set, {:var, 7}, {:call, PropCheck.Test.BrokenTicketIssuerTest, :inc, []}}, {:set, {:var, 8}, {:call, PropCheck.Test.BrokenTicketIssuerTest, :inc, []}}]]} of type Tuple. This protocol is implemented for the following type(s): Date.Range, File.Stream, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, List, Map, MapSet, Range, Stream
     code: property "broken ticket issuer", [:verbose] do
     stacktrace:
       (elixir 1.13.4) lib/enum.ex:1: Enumerable.impl_for!/1
       (elixir 1.13.4) lib/enum.ex:143: Enumerable.reduce/3
       (elixir 1.13.4) lib/enum.ex:4144: Enum.reduce/3
       (propcheck 1.4.2-dev) lib/properties.ex:300: PropCheck.Properties.counter_example_inspect/1
       (propcheck 1.4.2-dev) lib/properties.ex:249: PropCheck.Properties.handle_check_results/2
       test/broken_ticket_issuer_test.exs:8: (test)
```

Also, while running a test several times to confirm the fix, another
bug was found for the case when the parallel execution counter-example
has an empty sequential prefix.  In that case, the counter-example was
not being classified as a parallel one, and printed incorrectly.

```
  1) property broken ticket issuer (PropCheck.Test.BrokenTicketIssuerTest)
     test/broken_ticket_issuer_test.exs:8
     Property Elixir.PropCheck.Test.BrokenTicketIssuerTest.property broken ticket issuer() failed. Counter-Example is:
     [
       {[],
        [
          [
            {:set, {:var, 2},
             {:call, PropCheck.Test.BrokenTicketIssuerTest, :inc, []}},
            {:set, {:var, 3},
             {:call, PropCheck.Test.BrokenTicketIssuerTest, :inc, []}},
            {:set, {:var, 4},
             {:call, PropCheck.Test.BrokenTicketIssuerTest, :inc, []}},
            {:set, {:var, 5},
             {:call, PropCheck.Test.BrokenTicketIssuerTest, :inc, []}}
          ],
          [
            {:set, {:var, 8},
             {:call, PropCheck.Test.BrokenTicketIssuerTest, :inc, []}}
          ]
        ]}
     ]
```