### PR TITLE
chore: removed redundant application declaration

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -59,9 +59,8 @@ defmodule PropCheck.Mixfile do
   # Type `mix help compile.app` for more information
   def application do
     [
-      applications: [:logger, :proper, :libgraph],
       mod: {PropCheck.App, []},
-      extra_applications: [:iex]
+      extra_applications: [:iex, :logger]
     ]
   end
 


### PR DESCRIPTION
There is no need to declare proper and libgraph in applications because they will be derived via deps automatically.
Currently you will also get the following warning when compiling propcheck.

`both :extra_applications and :applications was found in your mix.exs. You most likely want to remove the :applications key, as all applications are derived from your dependencies`

