### PR TITLE
ci: run tests for Elixir v1.16..v1.18

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -43,6 +43,9 @@ jobs:
     strategy:
       matrix:
         pair:
+          - { erlang: "27", elixir: "1.18", latest: true }
+          - { erlang: "27", elixir: "1.17", latest: true }
+          - { erlang: "26", elixir: "1.16", latest: true }
           - { erlang: "26", elixir: "1.15", latest: true }
           - { erlang: "26", elixir: "1.14" }
           - { erlang: "25", elixir: "1.14" }


### PR DESCRIPTION
This extends the github action matrix to run the tests for Elixir v1.16 through v1.18 as well.